### PR TITLE
[Feat] 사용자 정보 수정 기능 및 테스트

### DIFF
--- a/src/main/java/github/ticketflow/config/exception/auth/AuthErrorCode.java
+++ b/src/main/java/github/ticketflow/config/exception/auth/AuthErrorCode.java
@@ -10,8 +10,8 @@ public enum AuthErrorCode {
 
     // user error
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일 입니다."),
-    FailLogin(HttpStatus.BAD_REQUEST, "로그인을 할 수 없습니다."),
-    FailUpdate(HttpStatus.BAD_REQUEST, "회원정보 수정에 실패했습니다."),
+    FAIL_LOGIN(HttpStatus.BAD_REQUEST, "로그인을 할 수 없습니다."),
+    FAIL_UPDATE(HttpStatus.BAD_REQUEST, "수정에 실패했습니다."),
 
     // token error
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),

--- a/src/main/java/github/ticketflow/config/exception/auth/AuthErrorCode.java
+++ b/src/main/java/github/ticketflow/config/exception/auth/AuthErrorCode.java
@@ -10,8 +10,8 @@ public enum AuthErrorCode {
 
     // user error
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일 입니다."),
-    NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "이메일을 찾을 수 없습니다."),
-    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
+    FailLogin(HttpStatus.BAD_REQUEST, "로그인을 할 수 없습니다."),
+    FailUpdate(HttpStatus.BAD_REQUEST, "회원정보 수정에 실패했습니다."),
 
     // token error
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),

--- a/src/main/java/github/ticketflow/config/exception/auth/AuthErrorCode.java
+++ b/src/main/java/github/ticketflow/config/exception/auth/AuthErrorCode.java
@@ -11,6 +11,7 @@ public enum AuthErrorCode {
     // user error
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일 입니다."),
     NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "이메일을 찾을 수 없습니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
 
     // token error
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),

--- a/src/main/java/github/ticketflow/config/login/CustomUserDetailsService.java
+++ b/src/main/java/github/ticketflow/config/login/CustomUserDetailsService.java
@@ -1,7 +1,8 @@
 package github.ticketflow.config.login;
 
-import github.ticketflow.config.exception.auth.AuthErrorCode;
+import github.ticketflow.config.exception.ErrorCode;
 import github.ticketflow.config.exception.GlobalCommonException;
+import github.ticketflow.config.exception.auth.AuthErrorCode;
 import github.ticketflow.domian.user.UserEntity;
 import github.ticketflow.domian.user.UserRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/github/ticketflow/config/login/CustomUserDetailsService.java
+++ b/src/main/java/github/ticketflow/config/login/CustomUserDetailsService.java
@@ -1,6 +1,5 @@
 package github.ticketflow.config.login;
 
-import github.ticketflow.config.exception.ErrorCode;
 import github.ticketflow.config.exception.GlobalCommonException;
 import github.ticketflow.config.exception.auth.AuthErrorCode;
 import github.ticketflow.domian.user.UserEntity;

--- a/src/main/java/github/ticketflow/config/login/CustomUserDetailsService.java
+++ b/src/main/java/github/ticketflow/config/login/CustomUserDetailsService.java
@@ -19,7 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
-        UserEntity userEntity = userRepository.findByEmail(email).orElseThrow(() -> new GlobalCommonException(AuthErrorCode.NOT_FOUND_EMAIL));
+        UserEntity userEntity = userRepository.findByEmail(email).orElseThrow(() -> new GlobalCommonException(AuthErrorCode.FAIL_LOGIN));
         return new CustomUserDetails(userEntity);
     }
 }

--- a/src/main/java/github/ticketflow/config/login/JWTFilter.java
+++ b/src/main/java/github/ticketflow/config/login/JWTFilter.java
@@ -30,9 +30,11 @@ public class JWTFilter extends OncePerRequestFilter {
         String token = authorizationHeader.replace("Bearer ", "");
 
         if(!jwtUtil.isExpired(token)) {
-            Authentication authentication = jwtUtil.getAuthentication(token);
+            Authentication authentication = jwtUtil.getAuthentication(jwtUtil.getEmail(token));
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
+
+
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/github/ticketflow/config/login/JWTUtil.java
+++ b/src/main/java/github/ticketflow/config/login/JWTUtil.java
@@ -43,7 +43,13 @@ public class JWTUtil {
     }
 
     public boolean isExpired(String token) {
-        boolean isExpired = Jwts.parser().verifyWith( createSecretKey(secret)).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+        boolean isExpired = Jwts
+                .parser()
+                .verifyWith(createSecretKey(secret))
+                .build().parseSignedClaims(token)
+                .getPayload().getExpiration()
+                .before(new Date());
+
         if (isExpired) {
             throw new GlobalCommonException(AuthErrorCode.TOKEN_EXPIRED);
         }
@@ -51,7 +57,12 @@ public class JWTUtil {
     }
 
     public String getEmail(String token) {
-        return Jwts.parser().verifyWith(createSecretKey(secret)).build().parseSignedClaims(token).getPayload().get("email", String.class);
+        return Jwts.parser()
+                .verifyWith(createSecretKey(secret))
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("email", String.class);
     }
 
     public Authentication getAuthentication(String email) {

--- a/src/main/java/github/ticketflow/config/login/JWTUtil.java
+++ b/src/main/java/github/ticketflow/config/login/JWTUtil.java
@@ -33,27 +33,29 @@ public class JWTUtil {
 
 
     public String createJwt(String username, Long id) {
-        SecretKey secretKey = createSecretKey(secret);
         return  Jwts.builder()
                 .claim("email", username)
                 .claim("user_id", id.toString())
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
-                .signWith(secretKey)
+                .signWith(createSecretKey(secret))
                 .compact();
     }
 
     public boolean isExpired(String token) {
-        SecretKey secretKey = createSecretKey(secret);
-        boolean isExpired = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+        boolean isExpired = Jwts.parser().verifyWith( createSecretKey(secret)).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
         if (isExpired) {
             throw new GlobalCommonException(AuthErrorCode.TOKEN_EXPIRED);
         }
         return isExpired;
     }
 
-    public Authentication getAuthentication(String token) {
-        UserDetails userDetails = userDetailsService.loadUserByUsername(token);
+    public String getEmail(String token) {
+        return Jwts.parser().verifyWith(createSecretKey(secret)).build().parseSignedClaims(token).getPayload().get("email", String.class);
+    }
+
+    public Authentication getAuthentication(String email) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 

--- a/src/main/java/github/ticketflow/config/login/LoginFilter.java
+++ b/src/main/java/github/ticketflow/config/login/LoginFilter.java
@@ -30,7 +30,6 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String password = request.getParameter("password");
 
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
-
         return authenticationManager.authenticate(authenticationToken);
 
     }

--- a/src/main/java/github/ticketflow/domian/user/UserController.java
+++ b/src/main/java/github/ticketflow/domian/user/UserController.java
@@ -1,0 +1,23 @@
+package github.ticketflow.domian.user;
+
+import github.ticketflow.domian.user.dto.UserResponseDTO;
+import github.ticketflow.domian.user.dto.UserUpdateRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PatchMapping("/user/{userId}")
+    public ResponseEntity<UserResponseDTO> updateUser(@PathVariable Long userId, @RequestBody UserUpdateRequestDTO dto) {
+        return  ResponseEntity.ok(userService.updateUser(userId, dto));
+    }
+
+}

--- a/src/main/java/github/ticketflow/domian/user/UserEntity.java
+++ b/src/main/java/github/ticketflow/domian/user/UserEntity.java
@@ -1,7 +1,9 @@
 package github.ticketflow.domian.user;
 
 import github.ticketflow.domian.auth.signUp.SignUpRequestDTO;
+import github.ticketflow.domian.user.dto.UserUpdateRequestDTO;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -9,6 +11,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+
 
 @Getter
 @Entity
@@ -42,8 +45,22 @@ public class UserEntity {
     @Column(name = "modify_at")
     private LocalDateTime modifiedDate;
 
+    public void update(UserUpdateRequestDTO dto) {
+        if(dto.getUsername() != null) this.username = dto.getUsername();
+        if(dto.getPhoneNumber() != null) this.phoneNumber = dto.getPhoneNumber();
+    }
+
 
     public UserEntity(String email, String password, String username, String phoneNumber) {
+        this.email = email;
+        this.password = password;
+        this.username = username;
+        this.phoneNumber = phoneNumber;
+    }
+
+    @Builder
+    public UserEntity(Long id, String email, String password, String username, String phoneNumber) {
+        this.id = id;
         this.email = email;
         this.password = password;
         this.username = username;

--- a/src/main/java/github/ticketflow/domian/user/UserService.java
+++ b/src/main/java/github/ticketflow/domian/user/UserService.java
@@ -16,7 +16,7 @@ public class UserService {
     public UserResponseDTO updateUser(Long userId, UserUpdateRequestDTO dto) {
         UserEntity userEntity = userRepository
                 .findById(userId)
-                .orElseThrow(() -> new GlobalCommonException(AuthErrorCode.FailUpdate));
+                .orElseThrow(() -> new GlobalCommonException(AuthErrorCode.FAIL_UPDATE));
 
         userEntity.update(dto);
         UserEntity updateUserEntity = userRepository.save(userEntity);

--- a/src/main/java/github/ticketflow/domian/user/UserService.java
+++ b/src/main/java/github/ticketflow/domian/user/UserService.java
@@ -16,7 +16,7 @@ public class UserService {
     public UserResponseDTO updateUser(Long userId, UserUpdateRequestDTO dto) {
         UserEntity userEntity = userRepository
                 .findById(userId)
-                .orElseThrow(() -> new GlobalCommonException(AuthErrorCode.NOT_FOUND_USER));
+                .orElseThrow(() -> new GlobalCommonException(AuthErrorCode.FailUpdate));
 
         userEntity.update(dto);
         UserEntity updateUserEntity = userRepository.save(userEntity);

--- a/src/main/java/github/ticketflow/domian/user/UserService.java
+++ b/src/main/java/github/ticketflow/domian/user/UserService.java
@@ -1,0 +1,26 @@
+package github.ticketflow.domian.user;
+
+import github.ticketflow.config.exception.GlobalCommonException;
+import github.ticketflow.config.exception.auth.AuthErrorCode;
+import github.ticketflow.domian.user.dto.UserResponseDTO;
+import github.ticketflow.domian.user.dto.UserUpdateRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserResponseDTO updateUser(Long userId, UserUpdateRequestDTO dto) {
+        UserEntity userEntity = userRepository
+                .findById(userId)
+                .orElseThrow(() -> new GlobalCommonException(AuthErrorCode.NOT_FOUND_USER));
+
+        userEntity.update(dto);
+        UserEntity updateUserEntity = userRepository.save(userEntity);
+
+        return new UserResponseDTO(updateUserEntity);
+    }
+}

--- a/src/main/java/github/ticketflow/domian/user/dto/UserResponseDTO.java
+++ b/src/main/java/github/ticketflow/domian/user/dto/UserResponseDTO.java
@@ -1,0 +1,23 @@
+package github.ticketflow.domian.user.dto;
+
+import github.ticketflow.domian.user.UserEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserResponseDTO {
+
+    private Long userId;
+    private String email;
+    private String username;
+    private String phoneNumber;
+
+
+    public UserResponseDTO(UserEntity userEntity) {
+        this.userId = userEntity.getId();
+        this.email = userEntity.getEmail();
+        this.username = userEntity.getUsername();
+        this.phoneNumber = userEntity.getPhoneNumber();
+    }
+}

--- a/src/main/java/github/ticketflow/domian/user/dto/UserUpdateRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/user/dto/UserUpdateRequestDTO.java
@@ -1,0 +1,14 @@
+package github.ticketflow.domian.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class UserUpdateRequestDTO {
+
+    private String username;
+    private String phoneNumber;
+
+}

--- a/src/test/java/github/ticketflow/domian/user/UserServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/user/UserServiceTest.java
@@ -1,0 +1,59 @@
+package github.ticketflow.domian.user;
+
+import github.ticketflow.domian.user.dto.UserResponseDTO;
+import github.ticketflow.domian.user.dto.UserUpdateRequestDTO;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @DisplayName("이름과 전화번호를 수정을 하면 수정된 정보가 나온다.")
+    @Test
+    void updateUserTest() {
+        // given
+        UserEntity userEntity = UserEntity.builder()
+                                    .id(1L)
+                                    .email("test1@gmail.com")
+                                    .password("dltkdgur12")
+                                    .username("이상혁")
+                                    .phoneNumber("01044554455")
+                                    .build();
+
+        BDDMockito.given(userRepository.save(any(UserEntity.class))).willReturn(userEntity);
+
+        UserUpdateRequestDTO dto = new UserUpdateRequestDTO("권예정", "01011111111");
+        BDDMockito.given(userRepository.findById(userEntity.getId())).willReturn(Optional.of(userEntity));
+
+
+        // when
+        UserResponseDTO updateUser = userService.updateUser(userEntity.getId(), dto);
+
+        // then
+        assertThat(updateUser)
+                .extracting("username", "phoneNumber")
+                .containsExactly("권예정", "01011111111");
+    }
+
+}


### PR DESCRIPTION
### 요약
사용자가 자인의 이름과 전화번호를 수정할 수 있는 기능과 테스트 코드를 작성을 했습니다.

### 상세 설명
- UserEntity의 username과 phoneNumber을 수정하는 메소드를 작성을 했습니다.
- UserUpdateRequest와 UserRespose를 통해서 수정하는 값을 받고 수정된 값을 전달하였습니다!
- JWT token에서 token을 통해서 email을 가지고 오는 메소드를 작성을 했습니다.
- Controller와 Service에서 회원의 정보를 수정하는 로직을 작성을 했습니다.
- 회원 정보를 수정하는 단위 테스트를 진행을 했습니다.

###
- 사용자가 username과 phoneNumber을 수정하고 싶은 값으로 넣고 그 값이 잘 수정이 되었는지 확인하는 테스트를 작성을 했습니다.