### PR TITLE
[Feat] 이벤트 장소 CRUD 기능 작성 및 테스트 코드 작성

### DIFF
--- a/src/main/java/github/ticketflow/config/exception/eventLocation/EventLocationErrorResponsive.java
+++ b/src/main/java/github/ticketflow/config/exception/eventLocation/EventLocationErrorResponsive.java
@@ -1,0 +1,25 @@
+package github.ticketflow.config.exception.eventLocation;
+
+import github.ticketflow.config.exception.ErrorResponsive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum EventLocationErrorResponsive implements ErrorResponsive {
+    NOT_FOUND_EVENT_LOCATION(HttpStatus.NOT_FOUND, "이벤트 장소를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return "";
+    }
+}

--- a/src/main/java/github/ticketflow/config/exception/eventLocation/EventLocationErrorResponsive.java
+++ b/src/main/java/github/ticketflow/config/exception/eventLocation/EventLocationErrorResponsive.java
@@ -15,11 +15,11 @@ public enum EventLocationErrorResponsive implements ErrorResponsive {
 
     @Override
     public HttpStatus getStatus() {
-        return null;
+        return status;
     }
 
     @Override
     public String getMessage() {
-        return "";
+        return message;
     }
 }

--- a/src/main/java/github/ticketflow/domian/eventLocation/EventLocationController.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/EventLocationController.java
@@ -12,27 +12,28 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/event-location")
 public class EventLocationController {
 
     private final EventLocationService eventLocationService;
 
-    @GetMapping("/event-location/{eventLocationId}")
+    @GetMapping("/{eventLocationId}")
     public ResponseEntity<EventLocationResponseDTO> getEventLocationById(@PathVariable Long eventLocationId) {
         return ResponseEntity.ok(eventLocationService.getEventLocation(eventLocationId));
     }
 
-    @PostMapping("/event-location")
+    @PostMapping()
     public ResponseEntity<EventLocationResponseDTO> createEventLocation(@RequestBody EventLocationRequestDTO dto) {
         return ResponseEntity.ok(eventLocationService.createEventLocation(dto));
     }
 
-    @PatchMapping("/event-location/{eventLocationId}")
+    @PatchMapping("/{eventLocationId}")
     public ResponseEntity<EventLocationResponseDTO> updateEventLocation(@PathVariable Long eventLocationId,
                                                                         @RequestBody EventLocationUpdateRequestDTO dto) {
         return ResponseEntity.ok(eventLocationService.updateEventLocation(eventLocationId, dto));
     }
 
-    @DeleteMapping("/event-location/{eventLocationId}")
+    @DeleteMapping("/{eventLocationId}")
     public ResponseEntity<EventLocationResponseDTO> deleteEventLocation(@PathVariable Long eventLocationId) {
         return ResponseEntity.ok(eventLocationService.deletedEventLocation(eventLocationId));
     }

--- a/src/main/java/github/ticketflow/domian/eventLocation/EventLocationController.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/EventLocationController.java
@@ -22,7 +22,7 @@ public class EventLocationController {
         return ResponseEntity.ok(eventLocationService.getEventLocation(eventLocationId));
     }
 
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<EventLocationResponseDTO> createEventLocation(@RequestBody EventLocationRequestDTO dto) {
         return ResponseEntity.ok(eventLocationService.createEventLocation(dto));
     }

--- a/src/main/java/github/ticketflow/domian/eventLocation/EventLocationController.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/EventLocationController.java
@@ -1,0 +1,40 @@
+package github.ticketflow.domian.eventLocation;
+
+import github.ticketflow.domian.eventLocation.dto.EventLocationRequestDTO;
+import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
+import github.ticketflow.domian.eventLocation.dto.EventLocationUpdateRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class EventLocationController {
+
+    private final EventLocationService eventLocationService;
+
+    @GetMapping("/event-location/{eventLocationId}")
+    public ResponseEntity<EventLocationResponseDTO> getEventLocationById(@PathVariable Long eventLocationId) {
+        return ResponseEntity.ok(eventLocationService.getEventLocation(eventLocationId));
+    }
+
+    @PostMapping("/event-location")
+    public ResponseEntity<EventLocationResponseDTO> createEventLocation(@RequestBody EventLocationRequestDTO dto) {
+        return ResponseEntity.ok(eventLocationService.createEventLocation(dto));
+    }
+
+    @PatchMapping("/event-location/{eventLocationId}")
+    public ResponseEntity<EventLocationResponseDTO> updateEventLocation(@PathVariable Long eventLocationId,
+                                                                        @RequestBody EventLocationUpdateRequestDTO dto) {
+        return ResponseEntity.ok(eventLocationService.updateEventLocation(eventLocationId, dto));
+    }
+
+    @DeleteMapping("/event-location/{eventLocationId}")
+    public ResponseEntity<EventLocationResponseDTO> deleteEventLocation(@PathVariable Long eventLocationId) {
+        return ResponseEntity.ok(eventLocationService.deletedEventLocation(eventLocationId));
+    }
+
+}

--- a/src/main/java/github/ticketflow/domian/eventLocation/EventLocationEntity.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/EventLocationEntity.java
@@ -1,0 +1,46 @@
+package github.ticketflow.domian.eventLocation;
+
+import github.ticketflow.domian.eventLocation.dto.EventLocationRequestDTO;
+import github.ticketflow.domian.eventLocation.dto.EventLocationUpdateRequestDTO;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "EventLocation")
+public class EventLocationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_location_id")
+    private Long eventLocationId;
+
+    @Column(name = "event_location_name")
+    private String eventLocationName;
+
+    @Column(name = "total_seats")
+    private int totalSeats;
+
+
+    public EventLocationEntity(EventLocationRequestDTO dto) {
+        this.eventLocationName = dto.getEventLocationName();
+        this.totalSeats = dto.getTotalSeats();
+    }
+
+    public EventLocationEntity update(EventLocationUpdateRequestDTO dto) {
+        if (dto.getEventLocationName() != null) {
+            this.eventLocationName = dto.getEventLocationName();
+        }
+
+        if (dto.getTotalSeats() != this.totalSeats) {
+            this.totalSeats = dto.getTotalSeats();
+        }
+
+        return this;
+    }
+
+}

--- a/src/main/java/github/ticketflow/domian/eventLocation/EventLocationRepository.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/EventLocationRepository.java
@@ -1,0 +1,6 @@
+package github.ticketflow.domian.eventLocation;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventLocationRepository extends JpaRepository<EventLocationEntity, Long> {
+}

--- a/src/main/java/github/ticketflow/domian/eventLocation/EventLocationService.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/EventLocationService.java
@@ -7,6 +7,7 @@ import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
 import github.ticketflow.domian.eventLocation.dto.EventLocationUpdateRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +28,7 @@ public class EventLocationService {
         return new EventLocationResponseDTO(saveEventLocationEntity);
     }
 
-
+    @Transactional
     public EventLocationResponseDTO updateEventLocation(Long eventLocationId, EventLocationUpdateRequestDTO dto) {
         EventLocationEntity eventLocationEntity = getEventLocationEntityById(eventLocationId);
 
@@ -37,7 +38,7 @@ public class EventLocationService {
         return new EventLocationResponseDTO(saveEventLocationEntity);
     }
 
-
+    @Transactional
     public EventLocationResponseDTO deletedEventLocation(Long eventLocationId) {
         EventLocationEntity eventLocationEntity = getEventLocationEntityById(eventLocationId);
         eventLocationRepository.delete(eventLocationEntity);

--- a/src/main/java/github/ticketflow/domian/eventLocation/EventLocationService.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/EventLocationService.java
@@ -1,0 +1,53 @@
+package github.ticketflow.domian.eventLocation;
+
+import github.ticketflow.config.exception.GlobalCommonException;
+import github.ticketflow.config.exception.eventLocation.EventLocationErrorResponsive;
+import github.ticketflow.domian.eventLocation.dto.EventLocationRequestDTO;
+import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
+import github.ticketflow.domian.eventLocation.dto.EventLocationUpdateRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EventLocationService {
+
+    private final EventLocationRepository eventLocationRepository;
+
+    public EventLocationResponseDTO getEventLocation(Long eventLocationId) {
+        EventLocationEntity eventLocationEntity = getEventLocationEntityById(eventLocationId);
+        return new EventLocationResponseDTO(eventLocationEntity);
+    }
+
+    public EventLocationResponseDTO createEventLocation(EventLocationRequestDTO dto) {
+        EventLocationEntity saveEventLocationEntity = eventLocationRepository.save(new EventLocationEntity(dto));
+        return new EventLocationResponseDTO(saveEventLocationEntity);
+    }
+
+
+    public EventLocationResponseDTO updateEventLocation(Long eventLocationId, EventLocationUpdateRequestDTO dto) {
+        EventLocationEntity eventLocationEntity = getEventLocationEntityById(eventLocationId);
+
+        EventLocationEntity updateEventLocationEntity = eventLocationEntity.update(dto);
+        EventLocationEntity saveEventLocationEntity = eventLocationRepository.save(updateEventLocationEntity);
+
+        return new EventLocationResponseDTO(saveEventLocationEntity);
+    }
+
+
+    public EventLocationResponseDTO deletedEventLocation(Long eventLocationId) {
+        EventLocationEntity eventLocationEntity = getEventLocationEntityById(eventLocationId);
+        eventLocationRepository.delete(eventLocationEntity);
+        return new EventLocationResponseDTO(eventLocationEntity);
+    }
+
+    private EventLocationEntity getEventLocationEntityById(Long eventLocationId) {
+        EventLocationEntity eventLocationEntity = eventLocationRepository.findById(eventLocationId).orElseThrow(
+                () -> new GlobalCommonException(EventLocationErrorResponsive.NOT_FOUND_EVENT_LOCATION)
+        );
+        return eventLocationEntity;
+    }
+}

--- a/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationRequestDTO.java
@@ -1,6 +1,7 @@
 package github.ticketflow.domian.eventLocation.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,7 @@ public class EventLocationRequestDTO {
 
     @NotBlank
     private String eventLocationName;
-    @NotBlank
+    @NotNull
     private int totalSeats;
 
 }

--- a/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationRequestDTO.java
@@ -1,0 +1,18 @@
+package github.ticketflow.domian.eventLocation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventLocationRequestDTO {
+
+    @NotBlank
+    private String eventLocationName;
+    @NotBlank
+    private int totalSeats;
+
+}

--- a/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationResponseDTO.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationResponseDTO.java
@@ -1,0 +1,22 @@
+package github.ticketflow.domian.eventLocation.dto;
+
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventLocationResponseDTO {
+
+    private Long eventLocationId;
+    private String eventLocationName;
+    private int totalSeats;
+
+    public EventLocationResponseDTO(EventLocationEntity entity) {
+        this.eventLocationId = entity.getEventLocationId();
+        this.eventLocationName = entity.getEventLocationName();
+        this.totalSeats = entity.getTotalSeats();
+    }
+}

--- a/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationUpdateRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationUpdateRequestDTO.java
@@ -1,6 +1,7 @@
 package github.ticketflow.domian.eventLocation.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,7 @@ public class EventLocationUpdateRequestDTO {
 
     @NotBlank
     private String eventLocationName;
-    @NotBlank
+    @NotNull
     private int totalSeats;
 
 }

--- a/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationUpdateRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationUpdateRequestDTO.java
@@ -1,0 +1,18 @@
+package github.ticketflow.domian.eventLocation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventLocationUpdateRequestDTO {
+
+    @NotBlank
+    private String eventLocationName;
+    @NotBlank
+    private int totalSeats;
+
+}

--- a/src/test/java/github/ticketflow/domian/eventLocation/EventLocationServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/eventLocation/EventLocationServiceTest.java
@@ -1,0 +1,105 @@
+package github.ticketflow.domian.eventLocation;
+
+import github.ticketflow.domian.eventLocation.dto.EventLocationRequestDTO;
+import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
+import github.ticketflow.domian.eventLocation.dto.EventLocationUpdateRequestDTO;
+import jakarta.persistence.Id;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventLocationServiceTest {
+
+    @Mock
+    private EventLocationRepository eventLocationRepository;
+
+    @InjectMocks
+    private EventLocationService eventLocationService;
+
+    @DisplayName("eventLocationId로 eventLocation을 가지고 오면, 정보가 나온다.")
+    @Test
+    void getEventLocationByIdTest() {
+        // given
+        EventLocationEntity eventLocationEntity = new EventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        BDDMockito.given(eventLocationRepository.findById(eventLocationEntity.getEventLocationId()))
+                .willReturn(Optional.of(eventLocationEntity));
+
+        // when
+        EventLocationResponseDTO result = eventLocationService.getEventLocation(eventLocationEntity.getEventLocationId());
+
+        // then
+        assertThat(result).extracting("eventLocationId", "eventLocationName", "totalSeats")
+                .containsExactly(eventLocationEntity.getEventLocationId(), eventLocationEntity.getEventLocationName(), 50000);
+    }
+
+    @DisplayName("eventLocationRequestDTO로 eventLocation을 생성하면, 생성된 eventLocation의 정보가 나온다.")
+    @Test
+    void createEventLocationTest() {
+        // given
+        EventLocationRequestDTO dto = new EventLocationRequestDTO("서울 월드컵 경기자", 50000);
+        EventLocationEntity eventLocationEntity = new EventLocationEntity(dto);
+        BDDMockito.given(eventLocationRepository.save(any(EventLocationEntity.class)))
+                .willReturn(eventLocationEntity);
+
+
+        // when
+        EventLocationResponseDTO result = eventLocationService.createEventLocation(dto);
+
+        // then
+        assertThat(result).extracting("eventLocationName", "totalSeats")
+                .containsExactly(eventLocationEntity.getEventLocationName(), 50000);
+    }
+
+    @DisplayName("eventLocationId로 eventLocation을 가지고 와서 수정을 하면, 수정된 정보가 나온다.")
+    @Test
+    void updateEventLocationTest() {
+        // given
+        EventLocationEntity eventLocationEntity = new EventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        EventLocationUpdateRequestDTO dto = new EventLocationUpdateRequestDTO("빅버드 스타디움", 40000);
+        EventLocationEntity updateEventLocationEntity = eventLocationEntity.update(dto);
+
+        BDDMockito.given(eventLocationRepository
+                .findById(updateEventLocationEntity.getEventLocationId()))
+                .willReturn(Optional.of(updateEventLocationEntity));
+
+        BDDMockito.given(eventLocationRepository
+                .save(any(EventLocationEntity.class)))
+                .willReturn(updateEventLocationEntity);
+
+        // when
+        EventLocationResponseDTO result = eventLocationService.updateEventLocation(eventLocationEntity.getEventLocationId(), dto);
+
+        // then
+        assertThat(result).extracting("eventLocationId", "eventLocationName", "totalSeats")
+                .containsExactly(updateEventLocationEntity.getEventLocationId(), updateEventLocationEntity.getEventLocationName(), 40000);
+    }
+
+    @DisplayName("eventLocationId로 eventLocation을 가지고 와서 삭제를 하면, 삭제된 정보가 나온다.")
+    @Test
+    void deleteEventLocationTest() {
+        // given
+        EventLocationEntity eventLocationEntity = new EventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        BDDMockito.given(eventLocationRepository.findById(eventLocationEntity.getEventLocationId()))
+                .willReturn(Optional.of(eventLocationEntity));
+        BDDMockito.willDoNothing().given(eventLocationRepository).delete(eventLocationEntity);
+
+        // when
+        EventLocationResponseDTO result = eventLocationService.deletedEventLocation(eventLocationEntity.getEventLocationId());
+
+        // then
+        assertThat(result).extracting("eventLocationId", "eventLocationName", "totalSeats")
+                .containsExactly(eventLocationEntity.getEventLocationId(), eventLocationEntity.getEventLocationName(), 50000);
+    }
+
+}

--- a/src/test/java/github/ticketflow/domian/eventLocation/EventLocationServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/eventLocation/EventLocationServiceTest.java
@@ -47,7 +47,7 @@ class EventLocationServiceTest {
     @Test
     void createEventLocationTest() {
         // given
-        EventLocationRequestDTO dto = new EventLocationRequestDTO("서울 월드컵 경기자", 50000);
+        EventLocationRequestDTO dto = new EventLocationRequestDTO("서울 월드컵 경기장", 50000);
         EventLocationEntity eventLocationEntity = new EventLocationEntity(dto);
         BDDMockito.given(eventLocationRepository.save(any(EventLocationEntity.class)))
                 .willReturn(eventLocationEntity);


### PR DESCRIPTION
### 요약
이벤트 장소를 등록, 수정, 삭제, 조회하는 CRUD 기능을 작성을 하고 이에 대한 테스트 코드를 작성을 했습니다.

### 상세 설명
- 이벤트 장소에 대한 entity, repository, DTO, controller, service를 생성했습니다.
- entity에는 update에 필요한 update 메소드를 작성을 했습니다.
- controller, service에서는 CRUD 작업을 수행하는 비지니스 로직을 작성을 했습니다.
- 비지니스 로직의 행위에 대한 테스트 코드를 작성을 했습니다.

### 관련 이슈
이 PR은  #17 이슈를 해결하기 위해서 진행되었습니다.

### 테스트
- 테스트 코드는 CRUD에 대한 테스트 코드를 작성을 했습니다.
- 테스트의 목적은 비지니스 로직이 잘 실행이 되는 지에 대한 행위에 대해서 진행을 했습니다. 