### PR TITLE
[Feat] 좌석 등급 CRUD 기능 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/github/ticketflow/config/exception/seatGrade/SeatGradeErrorResponsive.java
+++ b/src/main/java/github/ticketflow/config/exception/seatGrade/SeatGradeErrorResponsive.java
@@ -1,0 +1,23 @@
+package github.ticketflow.config.exception.seatGrade;
+
+import github.ticketflow.config.exception.ErrorResponsive;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum SeatGradeErrorResponsive implements ErrorResponsive {
+    NOT_FOUND_SEAT_GRADE(HttpStatus.NOT_FOUND, "좌석 등급을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationResponseDTO.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationResponseDTO.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,5 +20,18 @@ public class EventLocationResponseDTO {
         this.eventLocationId = entity.getEventLocationId();
         this.eventLocationName = entity.getEventLocationName();
         this.totalSeats = entity.getTotalSeats();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EventLocationResponseDTO dto = (EventLocationResponseDTO) o;
+        return totalSeats == dto.totalSeats && Objects.equals(eventLocationId, dto.eventLocationId) && Objects.equals(eventLocationName, dto.eventLocationName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventLocationId, eventLocationName, totalSeats);
     }
 }

--- a/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeController.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeController.java
@@ -1,0 +1,44 @@
+package github.ticketflow.domian.seatGrade;
+
+import github.ticketflow.domian.seatGrade.dto.SeatGradeRequestDTO;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeResponseDTO;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeUpdateRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/seat-grade")
+public class SeatGradeController {
+
+    private final SeatGradeService seatGradeService;
+
+    @GetMapping("/{seatGradeId}")
+    public ResponseEntity<SeatGradeResponseDTO> getSeatGradeById(@PathVariable Long seatGradeId) {
+        return ResponseEntity.ok(seatGradeService.getSeatGradeById(seatGradeId));
+    }
+
+    @GetMapping("eventLocation/{eventLocationId}")
+    public ResponseEntity<List<SeatGradeResponseDTO>> getSeatGradeByEventLocation(@PathVariable Long eventLocationId) {
+        return ResponseEntity.ok(seatGradeService.getSeatGradeByEventLocationId(eventLocationId));
+    }
+
+    @PostMapping
+    public ResponseEntity<SeatGradeResponseDTO> createSeatGrade(@RequestBody SeatGradeRequestDTO dto) {
+        return ResponseEntity.ok(seatGradeService.createSeatGrade(dto));
+    }
+
+    @PatchMapping("/{seatGradeId}")
+    public ResponseEntity<SeatGradeResponseDTO> updateSeatGrade(@PathVariable Long seatGradeId,
+                                                                @RequestBody SeatGradeUpdateRequestDTO dto) {
+        return ResponseEntity.ok(seatGradeService.updateSeatGrade(seatGradeId, dto));
+    }
+
+    @DeleteMapping("/{seatGradeId}")
+    public ResponseEntity<SeatGradeResponseDTO> deleteSeatGrade(@PathVariable Long seatGradeId) {
+        return ResponseEntity.ok(seatGradeService.deletedSeatGrade(seatGradeId));
+    }
+}

--- a/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeController.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeController.java
@@ -21,7 +21,7 @@ public class SeatGradeController {
         return ResponseEntity.ok(seatGradeService.getSeatGradeById(seatGradeId));
     }
 
-    @GetMapping("eventLocation/{eventLocationId}")
+    @GetMapping("event-location/{eventLocationId}")
     public ResponseEntity<List<SeatGradeResponseDTO>> getSeatGradeByEventLocation(@PathVariable Long eventLocationId) {
         return ResponseEntity.ok(seatGradeService.getSeatGradeByEventLocationId(eventLocationId));
     }

--- a/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeEntity.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeEntity.java
@@ -39,7 +39,7 @@ public class SeatGradeEntity {
                            EventLocationEntity eventLocation) {
         this.eventLocation = eventLocation;
         this.seatGradeName = dto.getSeatGradeName();
-        this.seatGradePrice = BigDecimal.valueOf(dto.getSeatGradePrice());
+        this.seatGradePrice = dto.getSeatGradePrice();
         this.seatGradeTotalSeats = dto.getSeatGradeTotalSeats();
     }
 
@@ -51,8 +51,9 @@ public class SeatGradeEntity {
         if (dto.getSeatGradeName() != null) {
             this.seatGradeName = dto.getSeatGradeName();
         }
-        if (dto.getSeatGradePrice() != this.seatGradePrice.intValue()) {
-            this.seatGradePrice = BigDecimal.valueOf(dto.getSeatGradePrice());
+        if (dto.getSeatGradePrice() != null &&
+                !dto.getSeatGradePrice().equals(this.seatGradePrice)) {
+            this.seatGradePrice = dto.getSeatGradePrice();
         }
         if (dto.getSeatGradeTotalSeats() != this.seatGradeTotalSeats) {
             this.seatGradeTotalSeats = dto.getSeatGradeTotalSeats();

--- a/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeEntity.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeEntity.java
@@ -1,0 +1,62 @@
+package github.ticketflow.domian.seatGrade;
+
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeRequestDTO;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeUpdateRequestDTO;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "SeatGrade")
+public class SeatGradeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "seat_grade")
+    private Long seatGradeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_location_id")
+    private EventLocationEntity eventLocation;
+
+    @Column(name = "seat_grade_name")
+    private String seatGradeName;
+
+    @Column(name = "seat_grade_price")
+    private BigDecimal seatGradePrice;
+
+    @Column(name = "seat_grade_total_seats")
+    private int seatGradeTotalSeats;
+
+    public SeatGradeEntity(SeatGradeRequestDTO dto,
+                           EventLocationEntity eventLocation) {
+        this.eventLocation = eventLocation;
+        this.seatGradeName = dto.getSeatGradeName();
+        this.seatGradePrice = BigDecimal.valueOf(dto.getSeatGradePrice());
+        this.seatGradeTotalSeats = dto.getSeatGradeTotalSeats();
+    }
+
+    public SeatGradeEntity update(SeatGradeUpdateRequestDTO dto,
+                                  EventLocationEntity eventLocation) {
+        if (eventLocation != null) {
+            this.eventLocation = eventLocation;
+        }
+        if (dto.getSeatGradeName() != null) {
+            this.seatGradeName = dto.getSeatGradeName();
+        }
+        if (dto.getSeatGradePrice() != this.seatGradePrice.intValue()) {
+            this.seatGradePrice = BigDecimal.valueOf(dto.getSeatGradePrice());
+        }
+        if (dto.getSeatGradeTotalSeats() != this.seatGradeTotalSeats) {
+            this.seatGradeTotalSeats = dto.getSeatGradeTotalSeats();
+        }
+        return this;
+    }
+}

--- a/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeRepository.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeRepository.java
@@ -1,0 +1,11 @@
+package github.ticketflow.domian.seatGrade;
+
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SeatGradeRepository extends JpaRepository<SeatGradeEntity, Long> {
+
+    List<SeatGradeEntity> findAllByEventLocation(EventLocationEntity eventLocation);
+}

--- a/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeService.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeService.java
@@ -1,0 +1,90 @@
+package github.ticketflow.domian.seatGrade;
+
+import github.ticketflow.config.exception.GlobalCommonException;
+import github.ticketflow.config.exception.eventLocation.EventLocationErrorResponsive;
+import github.ticketflow.config.exception.seatGrade.SeatGradeErrorResponsive;
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.eventLocation.EventLocationRepository;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeRequestDTO;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeResponseDTO;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeUpdateRequestDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.beans.Transient;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SeatGradeService {
+
+    private final SeatGradeRepository seatGradeRepository;
+    private final EventLocationRepository eventLocationRepository;
+
+    public SeatGradeResponseDTO getSeatGradeById(Long seatGradeId) {
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(seatGradeId);
+
+        return new SeatGradeResponseDTO(seatGradeEntity);
+    }
+
+
+    @Transactional
+    public  List<SeatGradeResponseDTO> getSeatGradeByEventLocationId(Long eventLocationId) {
+        List<SeatGradeResponseDTO> seatGrades = new ArrayList<>();
+
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(eventLocationId);
+
+        List<SeatGradeEntity> seatGradeEntities = seatGradeRepository.findAllByEventLocation(eventLocationEntity);
+        seatGradeEntities.forEach(seatGradeEntity -> {
+            seatGrades.add(new SeatGradeResponseDTO(seatGradeEntity));
+        });
+
+        return seatGrades;
+    }
+
+    @Transactional
+    public SeatGradeResponseDTO createSeatGrade(SeatGradeRequestDTO dto) {
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(dto.getEventLocationId());
+        SeatGradeEntity seatGradeEntity = new SeatGradeEntity(dto, eventLocationEntity);
+        SeatGradeEntity saveSeatGradeEntity = seatGradeRepository.save(seatGradeEntity);
+
+        return new SeatGradeResponseDTO(saveSeatGradeEntity);
+    }
+
+    @Transactional
+    public SeatGradeResponseDTO updateSeatGrade(Long seatGradeId, SeatGradeUpdateRequestDTO dto) {
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(seatGradeId);
+        EventLocationEntity eventLocationEntity = null;
+        if (dto.getEventLocationId() != null) {
+            eventLocationEntity = getEventLocationEntity(dto.getEventLocationId());
+        }
+        SeatGradeEntity updateSeatGradeEntity = seatGradeEntity.update(dto, eventLocationEntity);
+        SeatGradeEntity saveSeatGradeEntity = seatGradeRepository.save(updateSeatGradeEntity);
+
+        return new SeatGradeResponseDTO(saveSeatGradeEntity);
+
+    }
+
+    @Transactional
+    public SeatGradeResponseDTO deletedSeatGrade(Long seatGradeId) {
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(seatGradeId);
+        seatGradeRepository.delete(seatGradeEntity);
+
+        return new SeatGradeResponseDTO(seatGradeEntity);
+    }
+
+    private SeatGradeEntity getSeatGradeEntity(Long seatGradeId) {
+        return seatGradeRepository.findById(seatGradeId).orElseThrow(() ->
+                new GlobalCommonException(SeatGradeErrorResponsive.NOT_FOUND_SEAT_GRADE)
+        );
+    }
+
+    private EventLocationEntity getEventLocationEntity(Long eventLocationId) {
+        return eventLocationRepository.findById(eventLocationId).orElseThrow(() ->
+                new GlobalCommonException(EventLocationErrorResponsive.NOT_FOUND_EVENT_LOCATION)
+        );
+    }
+}

--- a/src/main/java/github/ticketflow/domian/seatGrade/dto/SeatGradeRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/dto/SeatGradeRequestDTO.java
@@ -2,9 +2,12 @@ package github.ticketflow.domian.seatGrade.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
 
 @Getter
 @NoArgsConstructor
@@ -16,8 +19,8 @@ public class SeatGradeRequestDTO {
     @NotBlank
     private String seatGradeName;
     @NotNull
-    private int seatGradePrice;
-    @NotNull
+    private BigDecimal seatGradePrice;
+    @Positive
     private int seatGradeTotalSeats;
 
 }

--- a/src/main/java/github/ticketflow/domian/seatGrade/dto/SeatGradeRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/dto/SeatGradeRequestDTO.java
@@ -1,0 +1,23 @@
+package github.ticketflow.domian.seatGrade.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SeatGradeRequestDTO {
+
+    @NotBlank
+    private Long eventLocationId;
+    @NotBlank
+    private String seatGradeName;
+    @NotNull
+    private int seatGradePrice;
+    @NotNull
+    private int seatGradeTotalSeats;
+
+}

--- a/src/main/java/github/ticketflow/domian/seatGrade/dto/SeatGradeResponseDTO.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/dto/SeatGradeResponseDTO.java
@@ -1,0 +1,31 @@
+package github.ticketflow.domian.seatGrade.dto;
+
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.eventLocation.dto.EventLocationRequestDTO;
+import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SeatGradeResponseDTO {
+
+    private Long seatGradeId;
+    private EventLocationResponseDTO eventLocation;
+    private String seatGradeName;
+    private BigDecimal seatGradePrice;
+    private int seatGradeTotalSeats;
+
+    public SeatGradeResponseDTO(SeatGradeEntity seatGradeEntity) {
+        this.seatGradeId = seatGradeEntity.getSeatGradeId();
+        this.eventLocation = new EventLocationResponseDTO(seatGradeEntity.getEventLocation());
+        this.seatGradeName = seatGradeEntity.getSeatGradeName();
+        this.seatGradePrice = seatGradeEntity.getSeatGradePrice();
+        this.seatGradeTotalSeats = seatGradeEntity.getSeatGradeTotalSeats();
+    }
+}

--- a/src/main/java/github/ticketflow/domian/seatGrade/dto/SeatGradeUpdateRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/dto/SeatGradeUpdateRequestDTO.java
@@ -1,0 +1,19 @@
+package github.ticketflow.domian.seatGrade.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SeatGradeUpdateRequestDTO {
+
+    private Long eventLocationId;
+    private String seatGradeName;
+    private int seatGradePrice;
+    private int seatGradeTotalSeats;
+
+}

--- a/src/main/java/github/ticketflow/domian/seatGrade/dto/SeatGradeUpdateRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/dto/SeatGradeUpdateRequestDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -13,7 +15,7 @@ public class SeatGradeUpdateRequestDTO {
 
     private Long eventLocationId;
     private String seatGradeName;
-    private int seatGradePrice;
+    private BigDecimal seatGradePrice;
     private int seatGradeTotalSeats;
 
 }

--- a/src/test/java/github/ticketflow/domian/seatGrade/SeatGradeServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/seatGrade/SeatGradeServiceTest.java
@@ -1,0 +1,186 @@
+package github.ticketflow.domian.seatGrade;
+
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.eventLocation.EventLocationRepository;
+import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeRequestDTO;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeResponseDTO;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeUpdateRequestDTO;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import static org.mockito.ArgumentMatchers.any;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class SeatGradeServiceTest {
+
+    @Mock
+    private SeatGradeRepository seatGradeRepository;
+
+    @Mock
+    private EventLocationRepository eventLocationRepository;
+
+    @InjectMocks
+    private SeatGradeService seatGradeService;
+
+    @DisplayName("좌석 등급의 id로 좌석 등급을 가지고 오면, 좌석 등급의 정보가 나온다.")
+    @Test
+    void getSeatGradeByIdTest() {
+        // given
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        EventLocationResponseDTO dto = new EventLocationResponseDTO(eventLocationEntity);
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        BDDMockito.given(seatGradeRepository.findById(seatGradeEntity.getSeatGradeId()))
+                .willReturn(Optional.of(seatGradeEntity));
+
+        // when
+        SeatGradeResponseDTO result = seatGradeService.getSeatGradeById(seatGradeEntity.getSeatGradeId());
+
+        // then
+        assertThat(result)
+                .extracting("seatGradeId", "seatGradeName", "seatGradePrice", "seatGradeTotalSeats")
+                .contains(1L, seatGradeEntity.getSeatGradeName(), seatGradeEntity.getSeatGradePrice(), seatGradeEntity.getSeatGradeTotalSeats());
+
+        assertThat(result.getEventLocation()).isEqualTo(dto);
+    }
+
+
+
+    @DisplayName("이벤트 장소 id로 이벤트 장소에 있는 좌석 등급들을 가지고 올 수 있다.")
+    @Test
+    void getSeatGradeByEventLocationIdTest() {
+        // give
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        EventLocationResponseDTO dto = new EventLocationResponseDTO(eventLocationEntity);
+        SeatGradeEntity seatGradeEntity1st = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        SeatGradeEntity seatGradeEntity2nd = getSeatGradeEntity(2L, eventLocationEntity, "2등급", 100000, 15000);
+        SeatGradeEntity seatGradeEntity3rd = getSeatGradeEntity(3L, eventLocationEntity, "3등급", 50000, 30000);
+        List<SeatGradeEntity> seatGradeEntities = new ArrayList<>(List.of(seatGradeEntity1st, seatGradeEntity2nd, seatGradeEntity3rd));
+
+        BDDMockito.given(eventLocationRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(eventLocationEntity));
+
+        BDDMockito.given(seatGradeRepository.findAllByEventLocation(any(EventLocationEntity.class)))
+                .willReturn(seatGradeEntities);
+
+        // when
+        List<SeatGradeResponseDTO> result = seatGradeService.getSeatGradeByEventLocationId(eventLocationEntity.getEventLocationId());
+
+        // then
+        int sumTotalSeats = result.get(0).getSeatGradeTotalSeats() + result.get(1).getSeatGradeTotalSeats() + result.get(2).getSeatGradeTotalSeats();
+
+        assertThat(result).extracting("seatGradeId", "seatGradeName", "seatGradePrice", "seatGradeTotalSeats")
+                .containsExactlyInAnyOrder(
+                        tuple(seatGradeEntity1st.getSeatGradeId(), seatGradeEntity1st.getSeatGradeName(), seatGradeEntity1st.getSeatGradePrice(), seatGradeEntity1st.getSeatGradeTotalSeats()),
+                        tuple(seatGradeEntity2nd.getSeatGradeId(), seatGradeEntity2nd.getSeatGradeName(), seatGradeEntity2nd.getSeatGradePrice(), seatGradeEntity2nd.getSeatGradeTotalSeats()),
+                        tuple(seatGradeEntity3rd.getSeatGradeId(), seatGradeEntity3rd.getSeatGradeName(), seatGradeEntity3rd.getSeatGradePrice(), seatGradeEntity3rd.getSeatGradeTotalSeats())
+                );
+
+        assertThat(result.get(0).getEventLocation()).isEqualTo(dto);
+        assertThat(sumTotalSeats).isEqualTo(eventLocationEntity.getTotalSeats());
+    }
+
+    @DisplayName("새로운 좌석 등급을 생성을 하면, 새롭게 만들어진 좌석 등급이 생긴다.")
+    @Test
+    void createSeatGradeTest() {
+        // give
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        EventLocationResponseDTO dto = new EventLocationResponseDTO(eventLocationEntity);
+        SeatGradeRequestDTO seatGradeRequestDTO = new SeatGradeRequestDTO(1L, "1등급", 150000, 5000);
+        SeatGradeEntity seatGradeEntity = new SeatGradeEntity(seatGradeRequestDTO, eventLocationEntity);
+
+        BDDMockito.given(eventLocationRepository.findById(any(Long.class)))
+                        .willReturn(Optional.of(eventLocationEntity));
+
+        BDDMockito.given(seatGradeRepository.save(any(SeatGradeEntity.class)))
+                .willReturn(seatGradeEntity);
+
+        // when
+        SeatGradeResponseDTO result = seatGradeService.createSeatGrade(seatGradeRequestDTO);
+
+        // then
+        assertThat(result)
+                .extracting("seatGradeName", "seatGradePrice", "seatGradeTotalSeats")
+                .contains(seatGradeEntity.getSeatGradeName(), seatGradeEntity.getSeatGradePrice(), seatGradeEntity.getSeatGradeTotalSeats());
+
+        assertThat(result.getEventLocation()).isEqualTo(dto);
+
+    }
+
+    @DisplayName("원하는 정보를 수정하면, 수정된 정보가 나온다.")
+    @Test
+    void updateSeatGradeTest() {
+        // given
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+
+        SeatGradeUpdateRequestDTO seatGradeUpdateRequestDTO = SeatGradeUpdateRequestDTO.builder()
+                .seatGradePrice(200000)
+                .seatGradeTotalSeats(100000)
+                .build();
+
+        seatGradeEntity.update(seatGradeUpdateRequestDTO, eventLocationEntity);
+
+        BDDMockito.given(seatGradeRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(seatGradeEntity));
+
+        BDDMockito.given(seatGradeRepository.save(any(SeatGradeEntity.class)))
+                .willReturn(seatGradeEntity);
+
+        // when
+        SeatGradeResponseDTO result = seatGradeService.updateSeatGrade(seatGradeEntity.getSeatGradeId(), seatGradeUpdateRequestDTO);
+
+        // then
+        assertThat(result)
+                .extracting("seatGradeName", "seatGradePrice", "seatGradeTotalSeats")
+                .contains(seatGradeEntity.getSeatGradeName(), seatGradeEntity.getSeatGradePrice(), seatGradeEntity.getSeatGradeTotalSeats());
+    }
+
+    @DisplayName("좌석 등급을 삭제를 하면, 식제된 좌석 등급의 정보가 나온다.")
+    @Test
+    void deleteSeatGradeTest() {
+        // given
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        EventLocationResponseDTO dto = new EventLocationResponseDTO(eventLocationEntity);
+        BDDMockito.given(seatGradeRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(seatGradeEntity));
+
+        BDDMockito.willDoNothing().given(seatGradeRepository).delete(any(SeatGradeEntity.class));
+
+        // when
+        SeatGradeResponseDTO result = seatGradeService.deletedSeatGrade(seatGradeEntity.getSeatGradeId());
+
+        // then
+        assertThat(result)
+                .extracting("seatGradeId", "seatGradeName", "seatGradePrice", "seatGradeTotalSeats")
+                .contains(seatGradeEntity.getSeatGradeId(), seatGradeEntity.getSeatGradeName(), seatGradeEntity.getSeatGradePrice(), seatGradeEntity.getSeatGradeTotalSeats());
+
+        assertThat(result.getEventLocation()).isEqualTo(dto);
+
+    }
+
+    private static EventLocationEntity getEventLocationEntity(Long id, String name, int totalSeats) {
+        return new EventLocationEntity(id, name, totalSeats);
+    }
+
+    private static SeatGradeEntity getSeatGradeEntity(Long id, EventLocationEntity eventLocationEntity, String seatGrade, int price, int seatGradeTotalSeats) {
+        return new SeatGradeEntity(id, eventLocationEntity, seatGrade, BigDecimal.valueOf(price), seatGradeTotalSeats);
+    }
+
+}


### PR DESCRIPTION
### 요약
이벤트 장소에 있는 좌석 등급들을 등록할 수 있는 CRUD 기능을 구현읋 하고 이 CRUD에 대한 행위에 대해서 테스트 코드를 작성을 했습니다.

### 상세 설명
- SeatGrade에서 JoinColumn으로 Entity에 EventLocationEntity와 연결 관계를 맺었습니다.
- DTO는 Request, Response, UpdateRequest로 나누었으며, UpdateRequest는 수정을 할 때 사용이 됩니다.
- Controller와 service에는 CRUD에 대한 비지니스 로직을 작성을 했습니다.
- 모든 좌석 등급에 대한 정보를 가지고 오는 로직은 필요성을 느끼지 못해서 작성을 하지 않았습니다.
- 대신 좌석 등급을 개별로 가지고 오는 것과 이벤트 장소에 포함된 좌석 등급을 가지고 오도록 했습니다.
- 그리고 CRUD에 행위에 대해서 테스트 코드를 작성을 했습니다.

### 관련 이슈
이 PR은  #19 이슈를 해결하기 위해서 진행되었습니다.

### 테스트
- seatGradeId로 해당하는 데이터를 가지고 와서 정보를 잘 반환을 하는지 테스트를 했습니다.
- eventLocationId로 이벤트 장소에 해당하는 모든 좌석 등급 테이트를 list에 담아서 잘 반환을 하는지 테스트를 헸습니다.
- 좌석 정보를 잘 생성을 하고 봔환을 하는지 테스트를 했습니다.
- 원하는 정보만을 변경을 해서 변경된 정보가 잘 반환이 되는지 테스트를 했습니다.
- 삭제한 데이터를 잘 반환을 하는지 테스트를 했습니다.