### PR TITLE
[Feat] 좌석 CRUD 기능 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/github/ticketflow/config/exception/seat/SeatErrorResponsive.java
+++ b/src/main/java/github/ticketflow/config/exception/seat/SeatErrorResponsive.java
@@ -1,0 +1,24 @@
+package github.ticketflow.config.exception.seat;
+
+import github.ticketflow.config.exception.ErrorResponsive;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum SeatErrorResponsive implements ErrorResponsive {
+    NOT_FOUND_SEAT(HttpStatus.NOT_FOUND, "좌석을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/github/ticketflow/domian/category/CategoryController.java
+++ b/src/main/java/github/ticketflow/domian/category/CategoryController.java
@@ -3,6 +3,7 @@ package github.ticketflow.domian.category;
 import github.ticketflow.domian.category.dto.CategoryRequestDTO;
 import github.ticketflow.domian.category.dto.CategoryResponseDTO;
 import github.ticketflow.domian.category.dto.CategoryUpdateRequestDTO;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -32,13 +33,13 @@ public class CategoryController {
     }
 
     @PostMapping
-    public ResponseEntity<CategoryResponseDTO> createCategory(@RequestBody CategoryRequestDTO dto) {
+    public ResponseEntity<CategoryResponseDTO> createCategory(@Valid  @RequestBody CategoryRequestDTO dto) {
          return ResponseEntity.ok(categoryService.createCategory(dto));
     }
 
     @PatchMapping("/{categoryId}")
     public ResponseEntity<CategoryResponseDTO> updateCategory(@PathVariable Long categoryId,
-                                                              @RequestBody CategoryUpdateRequestDTO dto) {
+                                                              @Valid @RequestBody CategoryUpdateRequestDTO dto) {
         return ResponseEntity.ok(categoryService.updateCategory(categoryId, dto));
     }
 

--- a/src/main/java/github/ticketflow/domian/category/dto/CategoryRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/category/dto/CategoryRequestDTO.java
@@ -1,6 +1,7 @@
 package github.ticketflow.domian.category.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +14,7 @@ public class CategoryRequestDTO {
     @NotBlank
     private String categoryName;
 
-    @NotBlank
+    @Positive
     private int categoryLevel;
 
     private Long parentCategoryId;

--- a/src/main/java/github/ticketflow/domian/eventLocation/EventLocationController.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/EventLocationController.java
@@ -3,6 +3,7 @@ package github.ticketflow.domian.eventLocation;
 import github.ticketflow.domian.eventLocation.dto.EventLocationRequestDTO;
 import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
 import github.ticketflow.domian.eventLocation.dto.EventLocationUpdateRequestDTO;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
@@ -23,13 +24,13 @@ public class EventLocationController {
     }
 
     @PostMapping
-    public ResponseEntity<EventLocationResponseDTO> createEventLocation(@RequestBody EventLocationRequestDTO dto) {
+    public ResponseEntity<EventLocationResponseDTO> createEventLocation(@Valid @RequestBody EventLocationRequestDTO dto) {
         return ResponseEntity.ok(eventLocationService.createEventLocation(dto));
     }
 
     @PatchMapping("/{eventLocationId}")
     public ResponseEntity<EventLocationResponseDTO> updateEventLocation(@PathVariable Long eventLocationId,
-                                                                        @RequestBody EventLocationUpdateRequestDTO dto) {
+                                                                        @Valid @RequestBody EventLocationUpdateRequestDTO dto) {
         return ResponseEntity.ok(eventLocationService.updateEventLocation(eventLocationId, dto));
     }
 

--- a/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/eventLocation/dto/EventLocationRequestDTO.java
@@ -2,6 +2,7 @@ package github.ticketflow.domian.eventLocation.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +14,7 @@ public class EventLocationRequestDTO {
 
     @NotBlank
     private String eventLocationName;
-    @NotNull
+    @Positive
     private int totalSeats;
 
 }

--- a/src/main/java/github/ticketflow/domian/seat/SeatController.java
+++ b/src/main/java/github/ticketflow/domian/seat/SeatController.java
@@ -1,0 +1,46 @@
+package github.ticketflow.domian.seat;
+
+import github.ticketflow.domian.seat.dto.SeatRequestDTO;
+import github.ticketflow.domian.seat.dto.SeatResponseDTO;
+import github.ticketflow.domian.seat.dto.SeatUpdateRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/seat")
+public class SeatController {
+
+    private final SeatService seatService;
+
+    @GetMapping("/{seatId}")
+    public ResponseEntity<SeatResponseDTO> getSeatById(@PathVariable Long seatId) {
+        return ResponseEntity.ok(seatService.getSeatById(seatId));
+    }
+
+    @GetMapping("/{seatGradeId}")
+    public ResponseEntity<List<SeatResponseDTO>> getSeatByGradeId(@PathVariable Long seatGradeId) {
+        return ResponseEntity.ok(seatService.getSeatByGradeId(seatGradeId));
+    }
+
+    @PostMapping
+    public ResponseEntity<SeatResponseDTO> createSeat(@RequestBody SeatRequestDTO dto) {
+        return ResponseEntity.ok(seatService.createSeat(dto));
+    }
+
+    @PatchMapping("/{seatId}")
+    public ResponseEntity<SeatResponseDTO> updateSeat(@PathVariable Long seatId,
+                                                      @RequestBody SeatUpdateRequestDTO dto) {
+        return ResponseEntity.ok(seatService.updateSeat(seatId, dto));
+    }
+
+    @DeleteMapping("/{seatId}")
+    public ResponseEntity<SeatResponseDTO> deleteSeat(@PathVariable Long seatId) {
+        return ResponseEntity.ok(seatService.deletedSeat(seatId));
+    }
+
+
+}

--- a/src/main/java/github/ticketflow/domian/seat/SeatController.java
+++ b/src/main/java/github/ticketflow/domian/seat/SeatController.java
@@ -3,6 +3,7 @@ package github.ticketflow.domian.seat;
 import github.ticketflow.domian.seat.dto.SeatRequestDTO;
 import github.ticketflow.domian.seat.dto.SeatResponseDTO;
 import github.ticketflow.domian.seat.dto.SeatUpdateRequestDTO;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,13 +28,13 @@ public class SeatController {
     }
 
     @PostMapping
-    public ResponseEntity<SeatResponseDTO> createSeat(@RequestBody SeatRequestDTO dto) {
+    public ResponseEntity<SeatResponseDTO> createSeat(@Valid @RequestBody SeatRequestDTO dto) {
         return ResponseEntity.ok(seatService.createSeat(dto));
     }
 
     @PatchMapping("/{seatId}")
     public ResponseEntity<SeatResponseDTO> updateSeat(@PathVariable Long seatId,
-                                                      @RequestBody SeatUpdateRequestDTO dto) {
+                                                      @Valid @RequestBody SeatUpdateRequestDTO dto) {
         return ResponseEntity.ok(seatService.updateSeat(seatId, dto));
     }
 

--- a/src/main/java/github/ticketflow/domian/seat/SeatEntity.java
+++ b/src/main/java/github/ticketflow/domian/seat/SeatEntity.java
@@ -1,0 +1,59 @@
+package github.ticketflow.domian.seat;
+
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.seat.dto.SeatRequestDTO;
+import github.ticketflow.domian.seat.dto.SeatUpdateRequestDTO;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "Seat")
+public class SeatEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "seat_id")
+    private Long seatId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_grade_id")
+    private SeatGradeEntity seatGradeEntity;
+
+    @Column(name = "seat_zone")
+    private String seatZone;
+
+    @Column(name = "seat_row")
+    private int seatRow;
+
+    @Column(name = "seat_number")
+    private int seatNumber;
+
+    public SeatEntity(SeatRequestDTO dto, SeatGradeEntity seatGradeEntity) {
+        this.seatGradeEntity = seatGradeEntity;
+        this.seatZone = dto.getSeatZone();
+        this.seatRow = dto.getSeatRow();
+        this.seatNumber = dto.getSeatNumber();
+    }
+
+    public SeatEntity update(SeatUpdateRequestDTO dto, SeatGradeEntity seatGradeEntity) {
+        if(dto.getSeatZone() != null) {
+            this.seatZone = dto.getSeatZone();
+        }
+        if (dto.getSeatRow() != this.seatRow) {
+            this.seatRow = dto.getSeatRow();
+        }
+        if (dto.getSeatNumber() != this.seatNumber) {
+            this.seatNumber = dto.getSeatNumber();
+        }
+        if (seatGradeEntity != null) {
+            this.seatGradeEntity = seatGradeEntity;
+        }
+        return this;
+    }
+}

--- a/src/main/java/github/ticketflow/domian/seat/SeatRepository.java
+++ b/src/main/java/github/ticketflow/domian/seat/SeatRepository.java
@@ -1,0 +1,12 @@
+package github.ticketflow.domian.seat;
+
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SeatRepository extends JpaRepository<SeatEntity, Long> {
+
+    List<SeatEntity> findAllBySeatGradeEntity(SeatGradeEntity seatGradeEntity);
+
+}

--- a/src/main/java/github/ticketflow/domian/seat/SeatService.java
+++ b/src/main/java/github/ticketflow/domian/seat/SeatService.java
@@ -1,0 +1,87 @@
+package github.ticketflow.domian.seat;
+
+import github.ticketflow.config.exception.GlobalCommonException;
+import github.ticketflow.config.exception.seat.SeatErrorResponsive;
+import github.ticketflow.config.exception.seatGrade.SeatGradeErrorResponsive;
+import github.ticketflow.domian.seat.dto.SeatRequestDTO;
+import github.ticketflow.domian.seat.dto.SeatResponseDTO;
+import github.ticketflow.domian.seat.dto.SeatUpdateRequestDTO;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import github.ticketflow.domian.seatGrade.SeatGradeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SeatService {
+
+    private final SeatRepository seatRepository;
+    private final SeatGradeRepository seatGradeRepository;
+
+    public SeatResponseDTO getSeatById(Long seatId) {
+        SeatEntity seatEntity = getSeatEntity(seatId);
+
+        return new SeatResponseDTO(seatEntity);
+    }
+
+    @Transactional
+    public List<SeatResponseDTO> getSeatByGradeId(Long seatGradeId) {
+        List<SeatResponseDTO> seatResponseDTOList = new ArrayList<>();
+
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(seatGradeId);
+        List<SeatEntity> seatGradeEntities = seatRepository.findAllBySeatGradeEntity(seatGradeEntity);
+
+        seatGradeEntities.forEach(seatEntity -> {
+            seatResponseDTOList.add(new SeatResponseDTO(seatEntity));
+        });
+
+        return seatResponseDTOList;
+
+    }
+
+    public SeatResponseDTO createSeat(SeatRequestDTO dto) {
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(dto.getSeatGradeId());
+
+        SeatEntity seatEntity = new SeatEntity(dto, seatGradeEntity);
+        SeatEntity saveSeatEntity = seatRepository.save(seatEntity);
+
+        return new SeatResponseDTO(saveSeatEntity);
+    }
+
+    @Transactional
+    public SeatResponseDTO updateSeat(Long seatId, SeatUpdateRequestDTO dto) {
+        SeatGradeEntity seatGradeEntity = null;
+        if (dto.getSeatGradeId() != null) {
+            seatGradeEntity = seatGradeRepository.findById(dto.getSeatGradeId()).orElseThrow(() ->
+                    new GlobalCommonException(SeatErrorResponsive.NOT_FOUND_SEAT));
+        }
+
+        SeatEntity seatEntity = getSeatEntity(seatId);
+        seatEntity.update(dto, seatGradeEntity);
+        SeatEntity updateSeatEntity = seatRepository.save(seatEntity);
+
+        return new SeatResponseDTO(updateSeatEntity);
+    }
+
+    @Transactional
+    public SeatResponseDTO deletedSeat(Long seatId) {
+        SeatEntity seatEntity = getSeatEntity(seatId);
+
+        seatRepository.delete(seatEntity);
+        return new SeatResponseDTO(seatEntity);
+    }
+
+    private SeatEntity getSeatEntity(Long seatId) {
+       return seatRepository.findById(seatId).orElseThrow(() ->
+                new GlobalCommonException(SeatErrorResponsive.NOT_FOUND_SEAT));
+    }
+
+    private SeatGradeEntity getSeatGradeEntity(Long seatGradeId) {
+        return seatGradeRepository.findById(seatGradeId).orElseThrow(() ->
+                new GlobalCommonException(SeatGradeErrorResponsive.NOT_FOUND_SEAT_GRADE));
+    }
+}

--- a/src/main/java/github/ticketflow/domian/seat/dto/SeatRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/seat/dto/SeatRequestDTO.java
@@ -1,0 +1,23 @@
+package github.ticketflow.domian.seat.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SeatRequestDTO {
+
+    @NotNull
+    private Long seatGradeId;
+    @NotBlank
+    private String seatZone;
+    @NotNull
+    private int seatRow;
+    @NotNull
+    private int seatNumber;
+
+}

--- a/src/main/java/github/ticketflow/domian/seat/dto/SeatRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/seat/dto/SeatRequestDTO.java
@@ -2,6 +2,7 @@ package github.ticketflow.domian.seat.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,9 +16,9 @@ public class SeatRequestDTO {
     private Long seatGradeId;
     @NotBlank
     private String seatZone;
-    @NotNull
+    @Positive
     private int seatRow;
-    @NotNull
+    @Positive
     private int seatNumber;
 
 }

--- a/src/main/java/github/ticketflow/domian/seat/dto/SeatResponseDTO.java
+++ b/src/main/java/github/ticketflow/domian/seat/dto/SeatResponseDTO.java
@@ -1,0 +1,29 @@
+package github.ticketflow.domian.seat.dto;
+
+import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
+import github.ticketflow.domian.seat.SeatEntity;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SeatResponseDTO {
+
+    private Long seatId;
+    private SeatGradeResponseDTO seatGradeResponseDTO;
+    private EventLocationResponseDTO eventLocationResponseDTO;
+    private String seatZone;
+    private int seatRow;
+    private int seatNumber;
+
+    public SeatResponseDTO(SeatEntity seatEntity) {
+        this.seatId = seatEntity.getSeatId();
+        this.seatGradeResponseDTO = new SeatGradeResponseDTO(seatEntity.getSeatGradeEntity());
+        this.seatZone = seatEntity.getSeatZone();
+        this.seatRow = seatEntity.getSeatRow();
+        this.seatNumber = seatEntity.getSeatNumber();
+    }
+}

--- a/src/main/java/github/ticketflow/domian/seat/dto/SeatUpdateRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/seat/dto/SeatUpdateRequestDTO.java
@@ -1,0 +1,16 @@
+package github.ticketflow.domian.seat.dto;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SeatUpdateRequestDTO {
+
+    private Long seatGradeId;
+    private String seatZone;
+    private int seatRow;
+    private int seatNumber;
+
+}

--- a/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeController.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeController.java
@@ -3,6 +3,7 @@ package github.ticketflow.domian.seatGrade;
 import github.ticketflow.domian.seatGrade.dto.SeatGradeRequestDTO;
 import github.ticketflow.domian.seatGrade.dto.SeatGradeResponseDTO;
 import github.ticketflow.domian.seatGrade.dto.SeatGradeUpdateRequestDTO;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,13 +28,13 @@ public class SeatGradeController {
     }
 
     @PostMapping
-    public ResponseEntity<SeatGradeResponseDTO> createSeatGrade(@RequestBody SeatGradeRequestDTO dto) {
+    public ResponseEntity<SeatGradeResponseDTO> createSeatGrade(@Valid @RequestBody SeatGradeRequestDTO dto) {
         return ResponseEntity.ok(seatGradeService.createSeatGrade(dto));
     }
 
     @PatchMapping("/{seatGradeId}")
     public ResponseEntity<SeatGradeResponseDTO> updateSeatGrade(@PathVariable Long seatGradeId,
-                                                                @RequestBody SeatGradeUpdateRequestDTO dto) {
+                                                                @Valid @RequestBody SeatGradeUpdateRequestDTO dto) {
         return ResponseEntity.ok(seatGradeService.updateSeatGrade(seatGradeId, dto));
     }
 

--- a/src/main/java/github/ticketflow/domian/seatGrade/dto/SeatGradeResponseDTO.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/dto/SeatGradeResponseDTO.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor
@@ -27,5 +28,18 @@ public class SeatGradeResponseDTO {
         this.seatGradeName = seatGradeEntity.getSeatGradeName();
         this.seatGradePrice = seatGradeEntity.getSeatGradePrice();
         this.seatGradeTotalSeats = seatGradeEntity.getSeatGradeTotalSeats();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SeatGradeResponseDTO that = (SeatGradeResponseDTO) o;
+        return seatGradeTotalSeats == that.seatGradeTotalSeats && Objects.equals(seatGradeId, that.seatGradeId) && Objects.equals(eventLocation, that.eventLocation) && Objects.equals(seatGradeName, that.seatGradeName) && Objects.equals(seatGradePrice, that.seatGradePrice);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(seatGradeId, eventLocation, seatGradeName, seatGradePrice, seatGradeTotalSeats);
     }
 }

--- a/src/main/java/github/ticketflow/domian/user/UserController.java
+++ b/src/main/java/github/ticketflow/domian/user/UserController.java
@@ -2,6 +2,7 @@ package github.ticketflow.domian.user;
 
 import github.ticketflow.domian.user.dto.UserResponseDTO;
 import github.ticketflow.domian.user.dto.UserUpdateRequestDTO;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,7 +14,8 @@ public class UserController {
     private final UserService userService;
 
     @PatchMapping("/user/{userId}")
-    public ResponseEntity<UserResponseDTO> updateUser(@PathVariable Long userId, @RequestBody UserUpdateRequestDTO dto) {
+    public ResponseEntity<UserResponseDTO> updateUser(@PathVariable Long userId,
+                                                      @Valid @RequestBody UserUpdateRequestDTO dto) {
         return  ResponseEntity.ok(userService.updateUser(userId, dto));
     }
 

--- a/src/test/java/github/ticketflow/domian/seat/SeatServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/seat/SeatServiceTest.java
@@ -1,0 +1,200 @@
+package github.ticketflow.domian.seat;
+
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.seat.dto.SeatRequestDTO;
+import github.ticketflow.domian.seat.dto.SeatResponseDTO;
+import github.ticketflow.domian.seat.dto.SeatUpdateRequestDTO;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import github.ticketflow.domian.seatGrade.SeatGradeRepository;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeResponseDTO;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class SeatServiceTest {
+
+    @Mock
+    private SeatRepository seatRepository;
+
+    @Mock
+    private SeatGradeRepository seatGradeRepository;
+
+    @InjectMocks
+    private SeatService seatService;
+
+    @DisplayName("좌석의 id로 좌석을 가지고 오면, 정보를 반한을 한다.")
+    @Test
+    public void getSeatByIdTest() {
+        // given
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        SeatGradeResponseDTO dto = new SeatGradeResponseDTO(seatGradeEntity);
+        SeatEntity seatEntity = getSeatEntity(1L, seatGradeEntity, "1구역", 2, 25);
+
+        BDDMockito.given(seatRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(seatEntity));
+
+        // when
+        SeatResponseDTO result = seatService.getSeatById(seatEntity.getSeatId());
+
+        // then
+        assertThat(result)
+                .extracting("seatId", "seatZone", "seatRow", "seatNumber")
+                .contains(seatEntity.getSeatId(), seatEntity.getSeatZone(), seatEntity.getSeatNumber());
+
+        assertThat(result.getSeatGradeResponseDTO()).isEqualTo(dto);
+    }
+
+    @DisplayName("좌석 등급의 id로 좌석을 가지고 오면 리스트에 담에서 정보를 반환을 한다.")
+    @Test
+    void getSeatBySeatGradeTest() {
+        // given
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        SeatGradeResponseDTO dto = new SeatGradeResponseDTO(seatGradeEntity);
+        SeatEntity seatEntity1 = getSeatEntity(1L, seatGradeEntity, "1구역", 2, 25);
+        SeatEntity seatEntity2 = getSeatEntity(2L, seatGradeEntity, "1구역", 2, 26);
+        SeatEntity seatEntity3 = getSeatEntity(3L, seatGradeEntity, "1구역", 2, 27);
+        List<SeatEntity> seatEntities = new ArrayList<>(List.of(seatEntity1, seatEntity2, seatEntity3));
+
+
+        BDDMockito.given(seatGradeRepository.findById(any(Long.class)))
+                        .willReturn(Optional.of(seatGradeEntity));
+
+
+        BDDMockito.given(seatRepository.findAllBySeatGradeEntity(any(SeatGradeEntity.class)))
+                .willAnswer(invocationOnMock -> {
+                    Random random = new Random();
+                    int randomSize = random.nextInt(seatEntities.size()) + 1;
+                    return seatEntities.subList(0, randomSize);
+                });
+
+        // when
+        List<SeatResponseDTO> result = seatService.getSeatByGradeId(seatGradeEntity.getSeatGradeId());
+
+        // then
+        assertThat(result.size()).isBetween(1, 3);
+        assertThat(result)
+                .extracting("seatId", "seatZone", "seatRow", "seatNumber")
+                .containsAnyOf(
+                        tuple(seatEntity1.getSeatId(), seatEntity1.getSeatZone(), seatEntity1.getSeatRow(), seatEntity1.getSeatNumber()),
+                        tuple(seatEntity2.getSeatId(), seatEntity2.getSeatZone(), seatEntity2.getSeatRow(), seatEntity2.getSeatNumber()),
+                        tuple(seatEntity3.getSeatId(), seatEntity3.getSeatZone(), seatEntity3.getSeatRow(), seatEntity3.getSeatNumber())
+                );
+
+        assertThat(result.get(0).getSeatGradeResponseDTO()).isEqualTo(dto);
+    }
+
+    @DisplayName("좌석을 생성을 하면, 생성된 좌석의 정보가 반환이 된다.")
+    @Test
+    void createSeatTest() {
+        // given
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        SeatGradeResponseDTO dto = new SeatGradeResponseDTO(seatGradeEntity);
+        SeatRequestDTO seatRequestDTO = new SeatRequestDTO(seatGradeEntity.getSeatGradeId(),"1구역", 2, 25);
+        SeatEntity seatEntity = new SeatEntity(seatRequestDTO, seatGradeEntity);
+
+        BDDMockito.given(seatGradeRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(seatGradeEntity));
+
+        BDDMockito.given(seatRepository.save(any(SeatEntity.class)))
+                .willReturn(seatEntity);
+
+        // when
+        SeatResponseDTO result = seatService.createSeat(seatRequestDTO);
+
+        // then
+        assertThat(result)
+                .extracting("seatId", "seatZone", "seatRow", "seatNumber")
+                .contains(seatEntity.getSeatId(), seatEntity.getSeatZone(), seatEntity.getSeatNumber());
+
+        assertThat(result.getSeatGradeResponseDTO()).isEqualTo(dto);
+    }
+
+    @DisplayName("좌석의 정보를 수정하면, 수정된 좌석의 정보가 반환이 된다.")
+    @Test
+    void updateSeatTest() {
+        // given
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        SeatGradeResponseDTO dto = new SeatGradeResponseDTO(seatGradeEntity);
+        SeatUpdateRequestDTO updateDTO = SeatUpdateRequestDTO.builder()
+                .seatRow(3)
+                .seatNumber(36)
+                .build();
+        SeatEntity seatEntity = getSeatEntity(1L, seatGradeEntity, "1구역", 2, 25);
+
+        BDDMockito.given(seatRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(seatEntity));
+
+        BDDMockito.given(seatRepository.save(any(SeatEntity.class)))
+                .willReturn(seatEntity);
+
+        // when
+        SeatResponseDTO result = seatService.updateSeat(seatEntity.getSeatId(), updateDTO);
+
+        // then
+        assertThat(result)
+                .extracting("seatId", "seatZone", "seatRow", "seatNumber")
+                .contains(seatEntity.getSeatId(), seatEntity.getSeatZone(), seatEntity.getSeatNumber());
+
+        assertThat(result.getSeatGradeResponseDTO()).isEqualTo(dto);
+    }
+
+    @DisplayName("좌석을 삭제를 하면, 삭제된 좌석의 정보가 나온다.")
+    @Test
+    void deleteSeatTest() {
+        // given
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        SeatGradeResponseDTO dto = new SeatGradeResponseDTO(seatGradeEntity);
+        SeatEntity seatEntity = getSeatEntity(1L, seatGradeEntity, "1구역", 2, 25);
+        BDDMockito.given(seatRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(seatEntity));
+
+        BDDMockito.willDoNothing().given(seatRepository).delete(any(SeatEntity.class));
+
+        // when
+        SeatResponseDTO result = seatService.deletedSeat(seatEntity.getSeatId());
+
+        // then
+        assertThat(result)
+                .extracting("seatId", "seatZone", "seatRow", "seatNumber")
+                .contains(seatEntity.getSeatId(), seatEntity.getSeatZone(), seatEntity.getSeatNumber());
+
+        assertThat(result.getSeatGradeResponseDTO()).isEqualTo(dto);
+    }
+
+
+    private static SeatEntity getSeatEntity(Long id, SeatGradeEntity seatGradeEntity, String seatZone, int seatRow ,int seatNumber) {
+        return new SeatEntity(id, seatGradeEntity, seatZone, seatRow, seatNumber);
+    }
+
+    private static EventLocationEntity getEventLocationEntity(Long id, String name, int totalSeats) {
+        return new EventLocationEntity(id, name, totalSeats);
+    }
+
+    private static SeatGradeEntity getSeatGradeEntity(Long id, EventLocationEntity eventLocationEntity, String seatGrade, int price, int seatGradeTotalSeats) {
+        return new SeatGradeEntity(id, eventLocationEntity, seatGrade, BigDecimal.valueOf(price), seatGradeTotalSeats);
+    }
+
+}


### PR DESCRIPTION
### 요약
좌석 등급별로 하나 하나의 좌석을 생성, 조회, 수정, 삭제 할  수 있는 CRUD와 CRUD의 행위에 대한 테스트 코드를 작성을 했습니다!

### 상세 설명
- 좌석 하나 하나의 대한 CRUD 부분입니다.
- 좌석을 조회를 했을 떄, 좌석 등급의 정보가 나옵니다.
- 좌석 등급 안에는 이벤트 장소에 대한 정보도 담겨 있습니다.

### 관련 이슈
이 PR은  #21 이슈를 해결하기 위해서 진행되었습니다.

### 테스트
- 기본적인 CRUD에 행위에 대해서 테스트를 진행을 했습니다.
- 좌석의 등급으로 조회를 테스트하는 메소드에는 랜덤한 숫자로 리스트에 담은 객체의 수를 동적으로 헤서 테스트를 진행을 했습니다.