### PR TITLE
[Feat] 이벤트 등급별 좌석 정보

### DIFF
--- a/src/main/java/github/ticketflow/config/exception/gradeTicket/GradeTicketErrorResponsive.java
+++ b/src/main/java/github/ticketflow/config/exception/gradeTicket/GradeTicketErrorResponsive.java
@@ -1,0 +1,26 @@
+package github.ticketflow.config.exception.gradeTicket;
+
+import github.ticketflow.config.exception.ErrorResponsive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GradeTicketErrorResponsive implements ErrorResponsive {
+    NOT_FOUND_GRADE_TICKET(HttpStatus.NOT_FOUND, "등급별 좌석의 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/github/ticketflow/domian/deletedEvent/DeletedEventEntity.java
+++ b/src/main/java/github/ticketflow/domian/deletedEvent/DeletedEventEntity.java
@@ -56,7 +56,7 @@ public class DeletedEventEntity {
 
     public DeletedEventEntity(EventEntity eventEntity) {
         this.eventId = eventEntity.getEventId();
-        this.eventLocation = eventEntity.getEventLocation();
+        this.eventLocation = eventEntity.getEventLocationEntity();
         this.eventName = eventEntity.getEventName();
         this.eventDescription = eventEntity.getEventDescription();
         this.date = eventEntity.getDate();

--- a/src/main/java/github/ticketflow/domian/event/EventController.java
+++ b/src/main/java/github/ticketflow/domian/event/EventController.java
@@ -19,7 +19,7 @@ public class EventController {
 
     @GetMapping("/{eventId}")
     public ResponseEntity<EventResponseDTO> getEventById(@PathVariable Long eventId) {
-        return ResponseEntity.ok(eventFacade.getEventById(eventId));
+        return ResponseEntity.ok(new EventResponseDTO(eventFacade.getEventById(eventId)));
     }
 
     @GetMapping("/category/{categoryId}")
@@ -30,17 +30,17 @@ public class EventController {
 
     @PostMapping
     public ResponseEntity<EventResponseDTO> createEvent(@Valid @RequestBody EventRequestDTO dto) {
-        return ResponseEntity.ok(eventFacade.createEvent(dto));
+        return ResponseEntity.ok(new EventResponseDTO(eventFacade.createEvent(dto)));
     }
 
     @PatchMapping("/{eventId}")
     public ResponseEntity<EventResponseDTO> updateEvent(@PathVariable Long eventId,
                                                     @Valid @RequestBody EventUpdateRequestDTO dto) {
-        return ResponseEntity.ok(eventFacade.updateEvent(eventId, dto));
+        return ResponseEntity.ok(new EventResponseDTO(eventFacade.updateEvent(eventId, dto)));
     }
 
     @DeleteMapping("/{eventId}")
     public ResponseEntity<EventResponseDTO> deleteEvent(@PathVariable Long eventId) {
-        return ResponseEntity.ok(eventFacade.deletedEvent(eventId));
+        return ResponseEntity.ok(new EventResponseDTO(eventFacade.deletedEvent(eventId)));
     }
 }

--- a/src/main/java/github/ticketflow/domian/event/EventEntity.java
+++ b/src/main/java/github/ticketflow/domian/event/EventEntity.java
@@ -109,6 +109,6 @@ public class EventEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(eventId, eventLocationEntity, eventName, eventDescription, date, startTime, createdAt, modifiedAt);
+        return Objects.hash(eventId);
     }
 }

--- a/src/main/java/github/ticketflow/domian/event/EventEntity.java
+++ b/src/main/java/github/ticketflow/domian/event/EventEntity.java
@@ -31,7 +31,7 @@ public class EventEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_location_id")
-    private EventLocationEntity eventLocation;
+    private EventLocationEntity eventLocationEntity;
 
     @Column(name = "event_name")
     private String eventName;
@@ -54,7 +54,7 @@ public class EventEntity {
     private LocalDate modifiedAt;
 
     public EventEntity(EventRequestDTO dto, EventLocationEntity eventLocationEntity) {
-        this.eventLocation = eventLocationEntity;
+        this.eventLocationEntity = eventLocationEntity;
         this.eventName = dto.getEventName();
         this.eventDescription = dto.getEventDescription();
         this.date = dto.getDate();
@@ -63,7 +63,7 @@ public class EventEntity {
 
     public EventEntity(EventResponseDTO dto) {
         this.eventId = dto.getEventId();
-        this.eventLocation = new EventLocationEntity(dto.getEventLocationResponseDTO());
+        this.eventLocationEntity = new EventLocationEntity(dto.getEventLocationResponseDTO());
         this.eventName = dto.getEventName();
         this.eventDescription = dto.getEventDescription();
         this.date = dto.getDate();
@@ -78,7 +78,7 @@ public class EventEntity {
 
     public EventEntity update(EventUpdateRequestDTO dto, EventLocationEntity eventLocationEntity) {
         if (eventLocationEntity != null) {
-            this.eventLocation = eventLocationEntity;
+            this.eventLocationEntity = eventLocationEntity;
         }
         return getEventEntity(dto);
     }
@@ -109,6 +109,6 @@ public class EventEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(eventId, eventLocation, eventName, eventDescription, date, startTime, createdAt, modifiedAt);
+        return Objects.hash(eventId, eventLocationEntity, eventName, eventDescription, date, startTime, createdAt, modifiedAt);
     }
 }

--- a/src/main/java/github/ticketflow/domian/event/EventEntity.java
+++ b/src/main/java/github/ticketflow/domian/event/EventEntity.java
@@ -98,4 +98,17 @@ public class EventEntity {
         }
         return this;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EventEntity that = (EventEntity) o;
+        return Objects.equals(eventId, that.eventId) && Objects.equals(eventLocation, that.eventLocation) && Objects.equals(eventName, that.eventName) && Objects.equals(eventDescription, that.eventDescription) && Objects.equals(date, that.date) && Objects.equals(startTime, that.startTime) && Objects.equals(createdAt, that.createdAt) && Objects.equals(modifiedAt, that.modifiedAt);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventId, eventLocation, eventName, eventDescription, date, startTime, createdAt, modifiedAt);
+    }
 }

--- a/src/main/java/github/ticketflow/domian/event/EventEntity.java
+++ b/src/main/java/github/ticketflow/domian/event/EventEntity.java
@@ -104,7 +104,7 @@ public class EventEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         EventEntity that = (EventEntity) o;
-        return Objects.equals(eventId, that.eventId) && Objects.equals(eventLocation, that.eventLocation) && Objects.equals(eventName, that.eventName) && Objects.equals(eventDescription, that.eventDescription) && Objects.equals(date, that.date) && Objects.equals(startTime, that.startTime) && Objects.equals(createdAt, that.createdAt) && Objects.equals(modifiedAt, that.modifiedAt);
+        return Objects.equals(eventId, that.eventId);
     }
 
     @Override

--- a/src/main/java/github/ticketflow/domian/event/EventFacade.java
+++ b/src/main/java/github/ticketflow/domian/event/EventFacade.java
@@ -30,8 +30,8 @@ public class EventFacade {
     private final CategoryEventService categoryEventService;
     private final DeletedEventService deletedEventService;
 
-    EventResponseDTO getEventById(Long eventId) {
-        return eventService.getEventById(eventId);
+    EventEntity getEventById(Long eventId) {
+        return  eventService.getEventById(eventId);
     }
 
     @Transactional
@@ -44,22 +44,21 @@ public class EventFacade {
     }
 
     @Transactional
-    EventResponseDTO createEvent(EventRequestDTO dto) {
+    EventEntity createEvent(EventRequestDTO dto) {
         EventLocationResponseDTO eventLocationResponseDTO = eventLocationService.getEventLocation(dto.getEventLocationId());
         EventLocationEntity eventLocationEntity = new EventLocationEntity(eventLocationResponseDTO);
 
         CategoryResponseDTO categoryResponseDTO =  categoryService.getCategory(dto.getCategoryId());
         CategoryEntity categoryEntity = new CategoryEntity(categoryResponseDTO);
 
-        EventResponseDTO eventResponseDTO = eventService.createEvent(dto, eventLocationEntity);
-        EventEntity eventEntity = new EventEntity(eventResponseDTO);
+        EventEntity eventEntity = eventService.createEvent(dto, eventLocationEntity);
 
         categoryEventService.createCategoryEvent(categoryEntity, eventEntity);
-        return  eventResponseDTO;
+        return eventEntity;
     }
 
     @Transactional
-    EventResponseDTO updateEvent(Long eventId, EventUpdateRequestDTO dto) {
+    EventEntity updateEvent(Long eventId, EventUpdateRequestDTO dto) {
         if (dto.getEventLocationId() == null) {
             return eventService.updateEvent(eventId, dto);
         }
@@ -71,13 +70,11 @@ public class EventFacade {
     }
 
     @Transactional
-    EventResponseDTO deletedEvent(Long eventId) {
-        EventResponseDTO eventResponseDTO = eventService.deletedEvent(eventId);
-        EventEntity eventEntity = new EventEntity(eventResponseDTO);
-
+    EventEntity deletedEvent(Long eventId) {
+        EventEntity eventEntity = eventService.deletedEvent(eventId);
         deletedEventService.createDeletedEvent(eventEntity);
 
-        return eventResponseDTO;
+        return eventEntity;
     }
 
 }

--- a/src/main/java/github/ticketflow/domian/event/EventService.java
+++ b/src/main/java/github/ticketflow/domian/event/EventService.java
@@ -22,10 +22,10 @@ public class EventService {
 
     private final EventRepository eventRepository;
 
-    public EventResponseDTO getEventById(Long eventId) {
-         EventEntity eventEntity = getEventEntity(eventId);
-
-        return new EventResponseDTO(eventEntity);
+    public EventEntity getEventById(Long eventId) {
+        return eventRepository.findById(eventId).orElseThrow(() ->
+                new GlobalCommonException(EventErrorResponsive.NOT_FOUND_EVENT)
+        );
     }
 
     public List<EventResponseDTO> getEventByCategoryId(Page<CategoryEventEntity> categoryEventEntities) {
@@ -38,39 +38,32 @@ public class EventService {
         return eventEntities;
     }
 
-    public EventResponseDTO createEvent(EventRequestDTO dto,
+    public EventEntity createEvent(EventRequestDTO dto,
                                    EventLocationEntity eventLocationEntity) {
         EventEntity newEventEntity = new EventEntity(dto, eventLocationEntity);
-        EventEntity saveEventEntity = eventRepository.save(newEventEntity);
-        return  new EventResponseDTO(saveEventEntity);
+        return eventRepository.save(newEventEntity);
     }
 
-    public EventResponseDTO updateEvent(Long eventId,
+    public EventEntity updateEvent(Long eventId,
                                    EventUpdateRequestDTO dto) {
-        EventEntity eventEntity = getEventEntity(eventId);
+        EventEntity eventEntity = getEventById(eventId);
         EventEntity updateEventEntity = eventEntity.update(dto);
-        return new EventResponseDTO(eventRepository.save(updateEventEntity));
+        return eventRepository.save(updateEventEntity);
     }
 
-    public EventResponseDTO updateEvent(Long eventId,
+    public EventEntity updateEvent(Long eventId,
                                    EventUpdateRequestDTO dto,
                                    EventLocationEntity eventLocationEntity) {
-        EventEntity eventEntity = getEventEntity(eventId);
+        EventEntity eventEntity = getEventById(eventId);
         EventEntity updateEventEntity = eventEntity.update(dto, eventLocationEntity);
-        return new EventResponseDTO(eventRepository.save(updateEventEntity));
+        return eventRepository.save(updateEventEntity);
 
     }
 
-    public EventResponseDTO deletedEvent(Long eventId) {
-        EventEntity eventEntity = getEventEntity(eventId);
+    public EventEntity deletedEvent(Long eventId) {
+        EventEntity eventEntity = getEventById(eventId);
         eventRepository.delete(eventEntity);
 
-        return new EventResponseDTO(eventEntity);
-    }
-
-    private EventEntity getEventEntity(Long eventId) {
-        return eventRepository.findById(eventId).orElseThrow(() ->
-                new GlobalCommonException(EventErrorResponsive.NOT_FOUND_EVENT)
-        );
+        return eventEntity;
     }
 }

--- a/src/main/java/github/ticketflow/domian/event/dto/EventResponseDTO.java
+++ b/src/main/java/github/ticketflow/domian/event/dto/EventResponseDTO.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor
@@ -32,5 +33,18 @@ public class EventResponseDTO {
         this.startTime = eventEntity.getStartTime();
         this.createAt = eventEntity.getCreatedAt();
         this.modifyAt = eventEntity.getModifiedAt();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EventResponseDTO that = (EventResponseDTO) o;
+        return Objects.equals(eventId, that.eventId) && Objects.equals(eventLocationResponseDTO, that.eventLocationResponseDTO) && Objects.equals(eventName, that.eventName) && Objects.equals(eventDescription, that.eventDescription) && Objects.equals(date, that.date) && Objects.equals(startTime, that.startTime) && Objects.equals(createAt, that.createAt) && Objects.equals(modifyAt, that.modifyAt);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventId, eventLocationResponseDTO, eventName, eventDescription, date, startTime, createAt, modifyAt);
     }
 }

--- a/src/main/java/github/ticketflow/domian/event/dto/EventResponseDTO.java
+++ b/src/main/java/github/ticketflow/domian/event/dto/EventResponseDTO.java
@@ -26,7 +26,7 @@ public class EventResponseDTO {
 
     public EventResponseDTO(EventEntity eventEntity) {
         this.eventId = eventEntity.getEventId();
-        this.eventLocationResponseDTO = new EventLocationResponseDTO(eventEntity.getEventLocation());
+        this.eventLocationResponseDTO = new EventLocationResponseDTO(eventEntity.getEventLocationEntity());
         this.eventName = eventEntity.getEventName();
         this.eventDescription = eventEntity.getEventDescription();
         this.date = eventEntity.getDate();

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoController.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoController.java
@@ -1,0 +1,51 @@
+package github.ticketflow.domian.gradeTicketInfo;
+
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoRequestDTO;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoResponseDTO;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoUpdateRequestDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/grade-ticket-info")
+public class GradeTicketInfoController {
+
+    private final GradeTicketInfoFacade gradeTicketInfoFacade;
+
+    @GetMapping("/{gradeTicketInfoId}")
+    public ResponseEntity<GradeTicketInfoResponseDTO> getGradeTicketInfoById(@PathVariable Long gradeTicketInfoId) {
+        return ResponseEntity.ok(gradeTicketInfoFacade.getGradeTicketInfoById(gradeTicketInfoId));
+    }
+
+    @GetMapping("/{eventId}")
+    public ResponseEntity<List<GradeTicketInfoResponseDTO>> getGradeTicketInfoByEventEntity(@PathVariable Long eventId) {
+        return ResponseEntity.ok(gradeTicketInfoFacade.getGradeTicketInfoByEventEntity(eventId));
+    }
+
+    @GetMapping("/{eventId}/{seatGradeId}")
+    public ResponseEntity<GradeTicketInfoResponseDTO> getGradeTicketInfoByEventEntityAndSeatGradeEntity(@PathVariable Long eventId,
+                                                                                                @PathVariable Long seatGradeId) {
+        return ResponseEntity.ok(gradeTicketInfoFacade.getGradeTicketInfoByEventEntityAndSeatGradeEntity(eventId, seatGradeId));
+    }
+
+    @PostMapping
+    public ResponseEntity<GradeTicketInfoResponseDTO> createGradeTicketInfo(@Valid @RequestBody GradeTicketInfoRequestDTO dto) {
+        return ResponseEntity.ok(gradeTicketInfoFacade.createGradeTicketInfo(dto));
+    }
+
+    @PatchMapping("/{gradeTicketInfoId}")
+    public ResponseEntity<GradeTicketInfoResponseDTO> updateGradeTicketInfo(@PathVariable Long gradeTicketInfoId,
+                                                                            @Valid @RequestBody GradeTicketInfoUpdateRequestDTO dto) {
+        return ResponseEntity.ok(gradeTicketInfoFacade.updateGradeTicketInfo(gradeTicketInfoId, dto));
+    }
+    @DeleteMapping("/{gradeTicketInfoId}")
+    public ResponseEntity<GradeTicketInfoResponseDTO> deleteGradeTicketInfo(@PathVariable Long gradeTicketInfoId) {
+        return ResponseEntity.ok(gradeTicketInfoFacade.deleteGradeTicketInfo(gradeTicketInfoId));
+    }
+
+}

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoEntity.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoEntity.java
@@ -1,0 +1,90 @@
+package github.ticketflow.domian.gradeTicketInfo;
+
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoRequestDTO;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoUpdateRequestDTO;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "GradeTicketInfo")
+public class GradeTicketInfoEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "grade_ticket_info_id")
+    private Long gradeTicketInfoId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private EventEntity eventEntity;
+
+    @ManyToOne
+    @JoinColumn(name = "event_location_id")
+    private EventLocationEntity eventLocationEntity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_grade_id")
+    private SeatGradeEntity seatGradeEntity;
+
+    @Column(name = "number_total_ticket")
+    private int numberTotalTicket;
+
+    @Column(name = "number_of_remaining_tickets")
+    private int numberOfRemainingTickets;
+
+    public GradeTicketInfoEntity(GradeTicketInfoRequestDTO dto,
+                                 EventEntity eventEntity,
+                                 EventLocationEntity eventLocationEntity,
+                                 SeatGradeEntity seatGradeEntity) {
+        this.eventEntity = eventEntity;
+        this.eventLocationEntity = eventLocationEntity;
+        this.seatGradeEntity = seatGradeEntity;
+        this.numberTotalTicket = dto.getNumberTotalTicket();
+        this.numberOfRemainingTickets = dto.getNumberOfRemainingTickets();
+    }
+
+    public GradeTicketInfoEntity update(GradeTicketInfoUpdateRequestDTO dto) {
+        if (dto.getNumberTotalTicket() != this.numberTotalTicket) {
+            this.numberTotalTicket = dto.getNumberTotalTicket();
+        }
+
+        if (dto.getNumberOfRemainingTickets() != this.numberOfRemainingTickets) {
+            this.numberOfRemainingTickets = dto.getNumberOfRemainingTickets();
+        }
+
+        return this;
+    }
+
+    public GradeTicketInfoEntity update(GradeTicketInfoUpdateRequestDTO dto, GradeTicketInfoUpdate gradeTicketInfoUpdate) {
+        if (gradeTicketInfoUpdate.getEventEntity() != null) {
+            this.eventEntity = gradeTicketInfoUpdate.getEventEntity();
+            this.eventLocationEntity = gradeTicketInfoUpdate.getEventEntity().getEventLocation();
+        }
+
+        if (gradeTicketInfoUpdate.getEventLocationEntity() != null) {
+            this.eventLocationEntity = gradeTicketInfoUpdate.getEventLocationEntity();
+        }
+
+        if (gradeTicketInfoUpdate.getSeatGradeEntity() != null) {
+            this.seatGradeEntity = gradeTicketInfoUpdate.getSeatGradeEntity();
+        }
+
+        if (dto.getNumberTotalTicket() != this.numberTotalTicket) {
+            this.numberTotalTicket = dto.getNumberTotalTicket();
+        }
+
+        if (dto.getNumberOfRemainingTickets() != this.numberOfRemainingTickets) {
+            this.numberOfRemainingTickets = dto.getNumberOfRemainingTickets();
+        }
+
+        return this;
+    }
+}

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoEntity.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoEntity.java
@@ -7,6 +7,7 @@ import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoUpdateRequest
 import github.ticketflow.domian.seatGrade.SeatGradeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,6 +16,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Entity
 @Table(name = "GradeTicketInfo")
+@Builder
 public class GradeTicketInfoEntity {
 
     @Id

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoEntity.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoEntity.java
@@ -68,7 +68,7 @@ public class GradeTicketInfoEntity {
     public GradeTicketInfoEntity update(GradeTicketInfoUpdateRequestDTO dto, GradeTicketInfoUpdate gradeTicketInfoUpdate) {
         if (gradeTicketInfoUpdate.getEventEntity() != null) {
             this.eventEntity = gradeTicketInfoUpdate.getEventEntity();
-            this.eventLocationEntity = gradeTicketInfoUpdate.getEventEntity().getEventLocation();
+            this.eventLocationEntity = gradeTicketInfoUpdate.getEventEntity().getEventLocationEntity();
         }
 
         if (gradeTicketInfoUpdate.getEventLocationEntity() != null) {

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoFacade.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoFacade.java
@@ -1,0 +1,82 @@
+package github.ticketflow.domian.gradeTicketInfo;
+
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.event.EventService;
+import github.ticketflow.domian.event.dto.EventResponseDTO;
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoRequestDTO;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoResponseDTO;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoUpdateRequestDTO;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import github.ticketflow.domian.seatGrade.SeatGradeService;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GradeTicketInfoFacade {
+
+    private final GradeTicketInfoService gradeTicketInfoService;
+    private final EventService eventService;
+    private final SeatGradeService seatGradeService;
+
+    public GradeTicketInfoResponseDTO getGradeTicketInfoById(Long gradeTicketInfoId) {
+        return gradeTicketInfoService.getGradeTicketInfoById(gradeTicketInfoId);
+    }
+
+    public List<GradeTicketInfoResponseDTO> getGradeTicketInfoByEventEntity(Long eventId) {
+        EventEntity eventEntity = getEventEntity(eventId);
+
+        return gradeTicketInfoService.getGradeTicketInfoByEventEntity(eventEntity);
+    }
+
+    public GradeTicketInfoResponseDTO getGradeTicketInfoByEventEntityAndSeatGradeEntity(Long eventId, Long seatGradeId) {
+        EventEntity eventEntity = getEventEntity(eventId);
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(seatGradeId);
+
+        return gradeTicketInfoService.getGradeTicketInfoByEventEntityAndSeatGradeEntity(eventEntity, seatGradeEntity);
+    }
+
+    @Transactional
+    public GradeTicketInfoResponseDTO createGradeTicketInfo(GradeTicketInfoRequestDTO dto) {
+        EventEntity eventEntity = getEventEntity(dto.getEventId());
+        EventLocationEntity eventLocationEntity = eventEntity.getEventLocation();
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(dto.getSeatGradeId());
+
+        return gradeTicketInfoService.createGradeTicketInfo(dto, eventEntity, eventLocationEntity, seatGradeEntity);
+    }
+
+    @Transactional
+    public GradeTicketInfoResponseDTO updateGradeTicketInfo(Long gradeTicketInfoId, GradeTicketInfoUpdateRequestDTO dto) {
+        if (dto.getEventId() != null || dto.getEventLocationId() != null ||dto.getSeatGradeId() != null) {
+            EventEntity eventEntity = getEventEntity(dto.getEventId());
+            EventLocationEntity eventLocationEntity = eventEntity.getEventLocation();
+            SeatGradeEntity seatGradeEntity = getSeatGradeEntity(dto.getSeatGradeId());
+            GradeTicketInfoUpdate gradeTicketInfoUpdate = new GradeTicketInfoUpdate(eventEntity, eventLocationEntity, seatGradeEntity);
+
+            return gradeTicketInfoService.updateGradeTicketInfo(gradeTicketInfoId, dto, gradeTicketInfoUpdate);
+        }
+        return gradeTicketInfoService.updateGradeTicketInfo(gradeTicketInfoId, dto);
+    }
+
+    @Transactional
+    public GradeTicketInfoResponseDTO deleteGradeTicketInfo(Long gradeTicketInfoId) {
+       return gradeTicketInfoService.deleteGradeTicketInfo(gradeTicketInfoId);
+    }
+
+    private EventEntity getEventEntity(Long eventId) {
+        EventResponseDTO eventResponseDTO = eventService.getEventById(eventId);
+        EventEntity eventEntity = new EventEntity(eventResponseDTO);
+        return eventEntity;
+    }
+
+    private SeatGradeEntity getSeatGradeEntity(Long seatGradeId) {
+        SeatGradeResponseDTO seatGradeResponseDTO = seatGradeService.getSeatGradeById(seatGradeId);
+        SeatGradeEntity seatGradeEntity = new SeatGradeEntity(seatGradeResponseDTO);
+        return seatGradeEntity;
+    }
+}

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoFacade.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoFacade.java
@@ -29,23 +29,23 @@ public class GradeTicketInfoFacade {
     }
 
     public List<GradeTicketInfoResponseDTO> getGradeTicketInfoByEventEntity(Long eventId) {
-        EventEntity eventEntity = getEventEntity(eventId);
+        EventEntity eventEntity = eventService.getEventById(eventId);
 
         return gradeTicketInfoService.getGradeTicketInfoByEventEntity(eventEntity);
     }
 
     public GradeTicketInfoResponseDTO getGradeTicketInfoByEventEntityAndSeatGradeEntity(Long eventId, Long seatGradeId) {
-        EventEntity eventEntity = getEventEntity(eventId);
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(seatGradeId);
+        EventEntity eventEntity = eventService.getEventById(eventId);
+        SeatGradeEntity seatGradeEntity = seatGradeService.getSeatGradeById(seatGradeId);
 
         return gradeTicketInfoService.getGradeTicketInfoByEventEntityAndSeatGradeEntity(eventEntity, seatGradeEntity);
     }
 
     @Transactional
     public GradeTicketInfoResponseDTO createGradeTicketInfo(GradeTicketInfoRequestDTO dto) {
-        EventEntity eventEntity = getEventEntity(dto.getEventId());
+        EventEntity eventEntity = eventService.getEventById(dto.getEventId());
         EventLocationEntity eventLocationEntity = eventEntity.getEventLocation();
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(dto.getSeatGradeId());
+        SeatGradeEntity seatGradeEntity = seatGradeService.getSeatGradeById(dto.getSeatGradeId());
 
         return gradeTicketInfoService.createGradeTicketInfo(dto, eventEntity, eventLocationEntity, seatGradeEntity);
     }
@@ -53,9 +53,9 @@ public class GradeTicketInfoFacade {
     @Transactional
     public GradeTicketInfoResponseDTO updateGradeTicketInfo(Long gradeTicketInfoId, GradeTicketInfoUpdateRequestDTO dto) {
         if (dto.getEventId() != null || dto.getEventLocationId() != null ||dto.getSeatGradeId() != null) {
-            EventEntity eventEntity = getEventEntity(dto.getEventId());
+            EventEntity eventEntity = eventService.getEventById(dto.getEventId());
             EventLocationEntity eventLocationEntity = eventEntity.getEventLocation();
-            SeatGradeEntity seatGradeEntity = getSeatGradeEntity(dto.getSeatGradeId());
+            SeatGradeEntity seatGradeEntity = seatGradeService.getSeatGradeById(dto.getSeatGradeId());
             GradeTicketInfoUpdate gradeTicketInfoUpdate = new GradeTicketInfoUpdate(eventEntity, eventLocationEntity, seatGradeEntity);
 
             return gradeTicketInfoService.updateGradeTicketInfo(gradeTicketInfoId, dto, gradeTicketInfoUpdate);
@@ -68,15 +68,4 @@ public class GradeTicketInfoFacade {
        return gradeTicketInfoService.deleteGradeTicketInfo(gradeTicketInfoId);
     }
 
-    private EventEntity getEventEntity(Long eventId) {
-        EventResponseDTO eventResponseDTO = eventService.getEventById(eventId);
-        EventEntity eventEntity = new EventEntity(eventResponseDTO);
-        return eventEntity;
-    }
-
-    private SeatGradeEntity getSeatGradeEntity(Long seatGradeId) {
-        SeatGradeResponseDTO seatGradeResponseDTO = seatGradeService.getSeatGradeById(seatGradeId);
-        SeatGradeEntity seatGradeEntity = new SeatGradeEntity(seatGradeResponseDTO);
-        return seatGradeEntity;
-    }
 }

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoFacade.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoFacade.java
@@ -44,7 +44,7 @@ public class GradeTicketInfoFacade {
     @Transactional
     public GradeTicketInfoResponseDTO createGradeTicketInfo(GradeTicketInfoRequestDTO dto) {
         EventEntity eventEntity = eventService.getEventById(dto.getEventId());
-        EventLocationEntity eventLocationEntity = eventEntity.getEventLocation();
+        EventLocationEntity eventLocationEntity = eventEntity.getEventLocationEntity();
         SeatGradeEntity seatGradeEntity = seatGradeService.getSeatGradeById(dto.getSeatGradeId());
 
         return gradeTicketInfoService.createGradeTicketInfo(dto, eventEntity, eventLocationEntity, seatGradeEntity);
@@ -54,7 +54,7 @@ public class GradeTicketInfoFacade {
     public GradeTicketInfoResponseDTO updateGradeTicketInfo(Long gradeTicketInfoId, GradeTicketInfoUpdateRequestDTO dto) {
         if (dto.getEventId() != null || dto.getEventLocationId() != null ||dto.getSeatGradeId() != null) {
             EventEntity eventEntity = eventService.getEventById(dto.getEventId());
-            EventLocationEntity eventLocationEntity = eventEntity.getEventLocation();
+            EventLocationEntity eventLocationEntity = eventEntity.getEventLocationEntity();
             SeatGradeEntity seatGradeEntity = seatGradeService.getSeatGradeById(dto.getSeatGradeId());
             GradeTicketInfoUpdate gradeTicketInfoUpdate = new GradeTicketInfoUpdate(eventEntity, eventLocationEntity, seatGradeEntity);
 

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoRepository.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoRepository.java
@@ -1,0 +1,17 @@
+package github.ticketflow.domian.gradeTicketInfo;
+
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.seat.SeatEntity;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GradeTicketInfoRepository extends JpaRepository<GradeTicketInfoEntity, Long> {
+
+    List<GradeTicketInfoEntity> findAllByEventEntity(EventEntity eventEntity);
+
+    Optional<GradeTicketInfoEntity> findByEventEntityAndSeatGradeEntity(EventEntity eventEntity, SeatGradeEntity seatGradeEntity);
+
+}

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoService.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoService.java
@@ -1,0 +1,96 @@
+package github.ticketflow.domian.gradeTicketInfo;
+
+import github.ticketflow.config.exception.GlobalCommonException;
+import github.ticketflow.config.exception.gradeTicket.GradeTicketErrorResponsive;
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoRequestDTO;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoResponseDTO;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoUpdateRequestDTO;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class GradeTicketInfoService {
+
+    private final GradeTicketInfoRepository gradeTicketInfoRepository;
+
+    public GradeTicketInfoResponseDTO getGradeTicketInfoById(Long gradeTicketInfoId) {
+        GradeTicketInfoEntity gradeTicketEntity = getGradeTicketInfoEntity(gradeTicketInfoId);
+
+        return new GradeTicketInfoResponseDTO(gradeTicketEntity);
+    }
+
+    public List<GradeTicketInfoResponseDTO> getGradeTicketInfoByEventEntity(EventEntity eventEntity) {
+        List<GradeTicketInfoResponseDTO> gradeTicketInfoResponseDTOS = new ArrayList<>();
+
+        List<GradeTicketInfoEntity> gradeTicketEntities = gradeTicketInfoRepository.findAllByEventEntity(eventEntity);
+
+        gradeTicketEntities.forEach(gradeTicketEntity -> {
+            gradeTicketInfoResponseDTOS.add(new GradeTicketInfoResponseDTO(gradeTicketEntity));
+        });
+
+        return gradeTicketInfoResponseDTOS;
+    }
+
+    public GradeTicketInfoResponseDTO getGradeTicketInfoByEventEntityAndSeatGradeEntity(EventEntity eventEntity, SeatGradeEntity seatGradeEntity) {
+        GradeTicketInfoEntity gradeTicketEntity = gradeTicketInfoRepository.findByEventEntityAndSeatGradeEntity(eventEntity, seatGradeEntity).orElseThrow(() ->
+                new GlobalCommonException(GradeTicketErrorResponsive.NOT_FOUND_GRADE_TICKET));
+
+        return new GradeTicketInfoResponseDTO(gradeTicketEntity);
+    }
+
+    public GradeTicketInfoResponseDTO createGradeTicketInfo(GradeTicketInfoRequestDTO dto,
+                                                            EventEntity eventEntity,
+                                                            EventLocationEntity eventLocationEntity,
+                                                            SeatGradeEntity seatGradeEntity) {
+
+        GradeTicketInfoEntity gradeTicketInfoEntity = new GradeTicketInfoEntity(dto, eventEntity, eventLocationEntity, seatGradeEntity);
+        GradeTicketInfoEntity saveGradeTicketInfoEntity = gradeTicketInfoRepository.save(gradeTicketInfoEntity);
+
+        return new GradeTicketInfoResponseDTO(saveGradeTicketInfoEntity);
+    }
+
+    public GradeTicketInfoResponseDTO updateGradeTicketInfo (Long gradeTicketInfoId,
+                                                             GradeTicketInfoUpdateRequestDTO dto
+                                                             ) {
+        GradeTicketInfoEntity gradeTicketEntity = getGradeTicketInfoEntity(gradeTicketInfoId);
+
+        gradeTicketEntity.update(dto);
+        GradeTicketInfoEntity updateGradeTicketEntity = gradeTicketInfoRepository.save(gradeTicketEntity);
+
+        return new GradeTicketInfoResponseDTO(updateGradeTicketEntity);
+    }
+
+    public GradeTicketInfoResponseDTO updateGradeTicketInfo (Long gradeTicketInfoId,
+                                                             GradeTicketInfoUpdateRequestDTO dto,
+                                                             GradeTicketInfoUpdate gradeTicketInfoUpdate) {
+        GradeTicketInfoEntity gradeTicketEntity = getGradeTicketInfoEntity(gradeTicketInfoId);
+
+        gradeTicketEntity.update(dto, gradeTicketInfoUpdate);
+        GradeTicketInfoEntity updateGradeTicketEntity = gradeTicketInfoRepository.save(gradeTicketEntity);
+
+        return new GradeTicketInfoResponseDTO(updateGradeTicketEntity);
+    }
+
+    public GradeTicketInfoResponseDTO deleteGradeTicketInfo(Long gradeTicketInfoId) {
+        GradeTicketInfoEntity gradeTicketEntity = getGradeTicketInfoEntity(gradeTicketInfoId);
+
+        gradeTicketInfoRepository.delete(gradeTicketEntity);
+
+        return new GradeTicketInfoResponseDTO(gradeTicketEntity);
+    }
+
+    private GradeTicketInfoEntity getGradeTicketInfoEntity(Long gradeTicketInfoId) {
+        GradeTicketInfoEntity gradeTicketEntity = gradeTicketInfoRepository.findById(gradeTicketInfoId).orElseThrow(() ->
+                new GlobalCommonException(GradeTicketErrorResponsive.NOT_FOUND_GRADE_TICKET));
+        return gradeTicketEntity;
+    }
+
+}

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoUpdate.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoUpdate.java
@@ -4,6 +4,7 @@ import github.ticketflow.domian.event.EventEntity;
 import github.ticketflow.domian.eventLocation.EventLocationEntity;
 import github.ticketflow.domian.seatGrade.SeatGradeEntity;
 
+import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
@@ -15,8 +16,11 @@ import lombok.Builder;
 @Builder
 public class GradeTicketInfoUpdate {
 
+    @Nullable
     private EventEntity eventEntity;
+    @Nullable
     private EventLocationEntity eventLocationEntity;
+    @Nullable
     private SeatGradeEntity seatGradeEntity;
 
 }

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoUpdate.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoUpdate.java
@@ -3,7 +3,11 @@ package github.ticketflow.domian.gradeTicketInfo;
 import github.ticketflow.domian.event.EventEntity;
 import github.ticketflow.domian.eventLocation.EventLocationEntity;
 import github.ticketflow.domian.seatGrade.SeatGradeEntity;
-import lombok.*;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 
 @Getter
 @NoArgsConstructor

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoUpdate.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoUpdate.java
@@ -1,0 +1,18 @@
+package github.ticketflow.domian.gradeTicketInfo;
+
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GradeTicketInfoUpdate {
+
+    private EventEntity eventEntity;
+    private EventLocationEntity eventLocationEntity;
+    private SeatGradeEntity seatGradeEntity;
+
+}

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/dto/GradeTicketInfoRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/dto/GradeTicketInfoRequestDTO.java
@@ -1,0 +1,23 @@
+package github.ticketflow.domian.gradeTicketInfo.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GradeTicketInfoRequestDTO {
+
+    @NotNull
+    private Long eventId;
+    @NotNull
+    private Long seatGradeId;
+    @Positive
+    private int numberTotalTicket;
+    @Positive
+    private int numberOfRemainingTickets;
+
+}

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/dto/GradeTicketInfoResponseDTO.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/dto/GradeTicketInfoResponseDTO.java
@@ -1,0 +1,32 @@
+package github.ticketflow.domian.gradeTicketInfo.dto;
+
+
+import github.ticketflow.domian.event.dto.EventResponseDTO;
+import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
+import github.ticketflow.domian.gradeTicketInfo.GradeTicketInfoEntity;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GradeTicketInfoResponseDTO {
+
+    private Long gradeTicketInfoId;
+    private EventResponseDTO eventResponseDTO;
+    private EventLocationResponseDTO eventLocationResponseDTO;
+    private SeatGradeResponseDTO seatGradeResponseDTO;
+    private int numberTotalTicket;
+    private int numberOfRemainingTickets;
+
+    public GradeTicketInfoResponseDTO(GradeTicketInfoEntity gradeTicketEntity) {
+        this.gradeTicketInfoId = gradeTicketEntity.getGradeTicketInfoId();
+        this.eventResponseDTO = new EventResponseDTO(gradeTicketEntity.getEventEntity());
+        this.eventLocationResponseDTO = new EventLocationResponseDTO(gradeTicketEntity.getEventLocationEntity());
+        this.seatGradeResponseDTO = new SeatGradeResponseDTO(gradeTicketEntity.getSeatGradeEntity());
+        this.numberTotalTicket = gradeTicketEntity.getNumberTotalTicket();
+        this.numberOfRemainingTickets = gradeTicketEntity.getNumberOfRemainingTickets();
+    }
+}

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/dto/GradeTicketInfoUpdateRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/dto/GradeTicketInfoUpdateRequestDTO.java
@@ -1,0 +1,18 @@
+package github.ticketflow.domian.gradeTicketInfo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GradeTicketInfoUpdateRequestDTO {
+
+    private Long eventId;
+    private Long eventLocationId;
+    private Long seatGradeId;
+    private Integer numberTotalTicket;
+    private Integer numberOfRemainingTickets;
+
+}

--- a/src/main/java/github/ticketflow/domian/gradeTicketInfo/dto/GradeTicketInfoUpdateRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/gradeTicketInfo/dto/GradeTicketInfoUpdateRequestDTO.java
@@ -1,12 +1,14 @@
 package github.ticketflow.domian.gradeTicketInfo.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class GradeTicketInfoUpdateRequestDTO {
 
     private Long eventId;

--- a/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeController.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeController.java
@@ -19,7 +19,7 @@ public class SeatGradeController {
 
     @GetMapping("/{seatGradeId}")
     public ResponseEntity<SeatGradeResponseDTO> getSeatGradeById(@PathVariable Long seatGradeId) {
-        return ResponseEntity.ok(seatGradeService.getSeatGradeById(seatGradeId));
+        return ResponseEntity.ok(new SeatGradeResponseDTO(seatGradeService.getSeatGradeById(seatGradeId)));
     }
 
     @GetMapping("event-location/{eventLocationId}")
@@ -29,17 +29,17 @@ public class SeatGradeController {
 
     @PostMapping
     public ResponseEntity<SeatGradeResponseDTO> createSeatGrade(@Valid @RequestBody SeatGradeRequestDTO dto) {
-        return ResponseEntity.ok(seatGradeService.createSeatGrade(dto));
+        return ResponseEntity.ok(new SeatGradeResponseDTO(seatGradeService.createSeatGrade(dto)));
     }
 
     @PatchMapping("/{seatGradeId}")
     public ResponseEntity<SeatGradeResponseDTO> updateSeatGrade(@PathVariable Long seatGradeId,
                                                                 @Valid @RequestBody SeatGradeUpdateRequestDTO dto) {
-        return ResponseEntity.ok(seatGradeService.updateSeatGrade(seatGradeId, dto));
+        return ResponseEntity.ok(new SeatGradeResponseDTO(seatGradeService.updateSeatGrade(seatGradeId, dto)));
     }
 
     @DeleteMapping("/{seatGradeId}")
     public ResponseEntity<SeatGradeResponseDTO> deleteSeatGrade(@PathVariable Long seatGradeId) {
-        return ResponseEntity.ok(seatGradeService.deletedSeatGrade(seatGradeId));
+        return ResponseEntity.ok(new SeatGradeResponseDTO(seatGradeService.deletedSeatGrade(seatGradeId)));
     }
 }

--- a/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeEntity.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeEntity.java
@@ -2,6 +2,7 @@ package github.ticketflow.domian.seatGrade;
 
 import github.ticketflow.domian.eventLocation.EventLocationEntity;
 import github.ticketflow.domian.seatGrade.dto.SeatGradeRequestDTO;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeResponseDTO;
 import github.ticketflow.domian.seatGrade.dto.SeatGradeUpdateRequestDTO;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -41,6 +42,14 @@ public class SeatGradeEntity {
         this.seatGradeName = dto.getSeatGradeName();
         this.seatGradePrice = dto.getSeatGradePrice();
         this.seatGradeTotalSeats = dto.getSeatGradeTotalSeats();
+    }
+
+    public SeatGradeEntity(SeatGradeResponseDTO responseDTO) {
+        this.seatGradeId = responseDTO.getSeatGradeId();
+        this.eventLocation = new EventLocationEntity(responseDTO.getEventLocation());
+        this.seatGradeName = responseDTO.getSeatGradeName();
+        this.seatGradePrice = responseDTO.getSeatGradePrice();
+        this.seatGradeTotalSeats = responseDTO.getSeatGradeTotalSeats();
     }
 
     public SeatGradeEntity update(SeatGradeUpdateRequestDTO dto,

--- a/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeEntity.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeEntity.java
@@ -6,16 +6,19 @@ import github.ticketflow.domian.seatGrade.dto.SeatGradeResponseDTO;
 import github.ticketflow.domian.seatGrade.dto.SeatGradeUpdateRequestDTO;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
 @Table(name = "SeatGrade")
+@Builder
 public class SeatGradeEntity {
 
     @Id

--- a/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeService.java
+++ b/src/main/java/github/ticketflow/domian/seatGrade/SeatGradeService.java
@@ -24,12 +24,11 @@ public class SeatGradeService {
     private final SeatGradeRepository seatGradeRepository;
     private final EventLocationRepository eventLocationRepository;
 
-    public SeatGradeResponseDTO getSeatGradeById(Long seatGradeId) {
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(seatGradeId);
-
-        return new SeatGradeResponseDTO(seatGradeEntity);
+    public SeatGradeEntity getSeatGradeById(Long seatGradeId) {
+        return seatGradeRepository.findById(seatGradeId).orElseThrow(() ->
+                new GlobalCommonException(SeatGradeErrorResponsive.NOT_FOUND_SEAT_GRADE)
+        );
     }
-
 
     @Transactional
     public  List<SeatGradeResponseDTO> getSeatGradeByEventLocationId(Long eventLocationId) {
@@ -46,40 +45,29 @@ public class SeatGradeService {
     }
 
     @Transactional
-    public SeatGradeResponseDTO createSeatGrade(SeatGradeRequestDTO dto) {
+    public SeatGradeEntity createSeatGrade(SeatGradeRequestDTO dto) {
         EventLocationEntity eventLocationEntity = getEventLocationEntity(dto.getEventLocationId());
         SeatGradeEntity seatGradeEntity = new SeatGradeEntity(dto, eventLocationEntity);
-        SeatGradeEntity saveSeatGradeEntity = seatGradeRepository.save(seatGradeEntity);
-
-        return new SeatGradeResponseDTO(saveSeatGradeEntity);
+        return seatGradeRepository.save(seatGradeEntity);
     }
 
     @Transactional
-    public SeatGradeResponseDTO updateSeatGrade(Long seatGradeId, SeatGradeUpdateRequestDTO dto) {
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(seatGradeId);
+    public SeatGradeEntity updateSeatGrade(Long seatGradeId, SeatGradeUpdateRequestDTO dto) {
+        SeatGradeEntity seatGradeEntity = getSeatGradeById(seatGradeId);
         EventLocationEntity eventLocationEntity = null;
         if (dto.getEventLocationId() != null) {
             eventLocationEntity = getEventLocationEntity(dto.getEventLocationId());
         }
         SeatGradeEntity updateSeatGradeEntity = seatGradeEntity.update(dto, eventLocationEntity);
-        SeatGradeEntity saveSeatGradeEntity = seatGradeRepository.save(updateSeatGradeEntity);
-
-        return new SeatGradeResponseDTO(saveSeatGradeEntity);
-
+        return seatGradeRepository.save(updateSeatGradeEntity);
     }
 
     @Transactional
-    public SeatGradeResponseDTO deletedSeatGrade(Long seatGradeId) {
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(seatGradeId);
+    public SeatGradeEntity deletedSeatGrade(Long seatGradeId) {
+        SeatGradeEntity seatGradeEntity = getSeatGradeById(seatGradeId);
         seatGradeRepository.delete(seatGradeEntity);
 
-        return new SeatGradeResponseDTO(seatGradeEntity);
-    }
-
-    private SeatGradeEntity getSeatGradeEntity(Long seatGradeId) {
-        return seatGradeRepository.findById(seatGradeId).orElseThrow(() ->
-                new GlobalCommonException(SeatGradeErrorResponsive.NOT_FOUND_SEAT_GRADE)
-        );
+        return seatGradeEntity;
     }
 
     private EventLocationEntity getEventLocationEntity(Long eventLocationId) {

--- a/src/test/java/github/ticketflow/domian/CategoryEvent/CategoryEventServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/CategoryEvent/CategoryEventServiceTest.java
@@ -88,7 +88,7 @@ class CategoryEventServiceTest {
                 .containsExactly("FC서울 vs 대전하나시티즌", "수원 삼성 vs 전남 드래곤즈", "울산현대 vs 전북현대");
 
         assertThat(result.getContent())
-                .extracting("eventEntity.eventLocation.eventLocationName")
+                .extracting("eventEntity.eventLocationEntity.eventLocationName")
                 .containsExactly("서울 월드컵 경기징", "수원 빅버드 경기징", "울산 문수 경기징");
 
     }
@@ -107,7 +107,7 @@ class CategoryEventServiceTest {
 
         EventEntity eventEntity = EventEntity.builder()
                 .eventId(1L)
-                .eventLocation(eventLocationEntity)
+                .eventLocationEntity(eventLocationEntity)
                 .eventName("FC 서울 vs 수원 삼성")
                 .eventDescription("축구 경기")
                 .date(LocalDate.of(2024, 10, 15))
@@ -135,7 +135,7 @@ class CategoryEventServiceTest {
     private static EventEntity getEventEntity(EventLocationEntity eventLocationEntity, String eventName) {
         return EventEntity.builder()
                 .eventId(1L)
-                .eventLocation(eventLocationEntity)
+                .eventLocationEntity(eventLocationEntity)
                 .eventName(eventName)
                 .eventDescription("축구 경기")
                 .date(LocalDate.of(2024, 10, 15))

--- a/src/test/java/github/ticketflow/domian/CommonTestFixture.java
+++ b/src/test/java/github/ticketflow/domian/CommonTestFixture.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-public class Fixture {
+public class CommonTestFixture {
 
     public static EventEntity getEventEntity(EventLocationEntity eventLocationEntity, String eventName) {
         return EventEntity.builder()

--- a/src/test/java/github/ticketflow/domian/Fixture.java
+++ b/src/test/java/github/ticketflow/domian/Fixture.java
@@ -14,7 +14,7 @@ public class Fixture {
     public static EventEntity getEventEntity(EventLocationEntity eventLocationEntity, String eventName) {
         return EventEntity.builder()
                 .eventId(1L)
-                .eventLocation(eventLocationEntity)
+                .eventLocationEntity(eventLocationEntity)
                 .eventName(eventName)
                 .eventDescription("축구 경기")
                 .date(LocalDate.of(2024, 10, 15))
@@ -40,7 +40,7 @@ public class Fixture {
         return GradeTicketInfoEntity.builder()
                 .gradeTicketInfoId(gradeTicketId)
                 .eventEntity(eventEntity)
-                .eventLocationEntity(eventEntity.getEventLocation())
+                .eventLocationEntity(eventEntity.getEventLocationEntity())
                 .seatGradeEntity(seatGradeEntity)
                 .numberTotalTicket(120)
                 .numberOfRemainingTickets(120)

--- a/src/test/java/github/ticketflow/domian/Fixture.java
+++ b/src/test/java/github/ticketflow/domian/Fixture.java
@@ -1,0 +1,50 @@
+package github.ticketflow.domian;
+
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.gradeTicketInfo.GradeTicketInfoEntity;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class Fixture {
+
+    public static EventEntity getEventEntity(EventLocationEntity eventLocationEntity, String eventName) {
+        return EventEntity.builder()
+                .eventId(1L)
+                .eventLocation(eventLocationEntity)
+                .eventName(eventName)
+                .eventDescription("축구 경기")
+                .date(LocalDate.of(2024, 10, 15))
+                .startTime(LocalTime.of(20, 30))
+                .build();
+    }
+
+    public static EventLocationEntity getEventLocationEntity(Long eventLocationId, String eventLocationName) {
+        return new EventLocationEntity(eventLocationId, eventLocationName, 50000);
+    }
+
+    public static SeatGradeEntity getSeatGradeEntity(Long seatGradeId, EventLocationEntity eventLocationEntity) {
+        return SeatGradeEntity.builder()
+                .seatGradeId(seatGradeId)
+                .eventLocation(eventLocationEntity)
+                .seatGradeName("1구역")
+                .seatGradePrice(BigDecimal.valueOf(100000))
+                .seatGradeTotalSeats(120)
+                .build();
+    }
+
+    public static GradeTicketInfoEntity gradeTicketInfoEntity(Long gradeTicketId, EventEntity eventEntity, SeatGradeEntity seatGradeEntity) {
+        return GradeTicketInfoEntity.builder()
+                .gradeTicketInfoId(gradeTicketId)
+                .eventEntity(eventEntity)
+                .eventLocationEntity(eventEntity.getEventLocation())
+                .seatGradeEntity(seatGradeEntity)
+                .numberTotalTicket(120)
+                .numberOfRemainingTickets(120)
+                .build();
+    }
+
+}

--- a/src/test/java/github/ticketflow/domian/deletedEvent/DeletedEventServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/deletedEvent/DeletedEventServiceTest.java
@@ -35,7 +35,7 @@ class DeletedEventServiceTest {
 
         EventEntity eventEntity = EventEntity.builder()
                 .eventId(1L)
-                .eventLocation(eventLocationEntity)
+                .eventLocationEntity(eventLocationEntity)
                 .eventName("FC 서울 vs 수원 삼성")
                 .eventDescription("축구 경기")
                 .date(LocalDate.of(2024, 10, 15))

--- a/src/test/java/github/ticketflow/domian/event/EventServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/event/EventServiceTest.java
@@ -52,8 +52,8 @@ class EventServiceTest {
         // then
         assertThat(result).extracting("eventName", "eventDescription", "date", "startTime")
                 .contains(eventEntity.getEventName(), eventEntity.getEventDescription(), eventEntity.getDate(), eventEntity.getStartTime());
-        assertThat(result).extracting("eventLocationResponseDTO")
-                .isEqualTo(new EventLocationResponseDTO(eventLocationEntity));
+        assertThat(result).extracting("EventLocationEntity")
+                .isEqualTo(eventLocationEntity);
     }
 
     @DisplayName("카테고리 id로 이벤트 목록을 가지고 오면, 리스트에 정보가 담긴다.")
@@ -134,7 +134,7 @@ class EventServiceTest {
         // then
         assertThat(result).extracting("eventName", "eventDescription", "date", "startTime")
                 .contains(eventEntity.getEventName(), eventEntity.getEventDescription(), eventEntity.getDate(),eventEntity.getStartTime());
-        assertThat(result).extracting("eventLocationResponseDTO")
+        assertThat(result).extracting("eventLocationEntity")
                 .isEqualTo(eventLocationEntity);
     }
 
@@ -191,7 +191,7 @@ class EventServiceTest {
     private static EventEntity getEventEntity(EventLocationEntity eventLocationEntity, String eventName) {
         return EventEntity.builder()
                 .eventId(1L)
-                .eventLocation(eventLocationEntity)
+                .eventLocationEntity(eventLocationEntity)
                 .eventName(eventName)
                 .eventDescription("축구 경기")
                 .date(LocalDate.of(2024, 10, 15))

--- a/src/test/java/github/ticketflow/domian/event/EventServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/event/EventServiceTest.java
@@ -47,7 +47,7 @@ class EventServiceTest {
                 .willReturn(Optional.of(eventEntity));
 
         // when
-        EventResponseDTO result = eventService.getEventById(any(Long.class));
+        EventEntity result = eventService.getEventById(any(Long.class));
 
         // then
         assertThat(result).extracting("eventName", "eventDescription", "date", "startTime")
@@ -124,27 +124,18 @@ class EventServiceTest {
 
         EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
         EventEntity eventEntity = getEventEntity(eventLocationEntity, dto.getEventName());
-        EventResponseDTO responseDTO = new EventResponseDTO(eventEntity);
-
-        CategoryEntity categoryEntity = CategoryEntity.builder()
-                .categoryId(1L)
-                .categoryName("스포츠")
-                .categoryLevel(1)
-                .build();
-
-        CategoryEventEntity categoryEventEntity = new CategoryEventEntity(categoryEntity, eventEntity);
 
         BDDMockito.given(eventRepository.save(any(EventEntity.class)))
                 .willReturn(eventEntity);
 
         // when
-        EventResponseDTO result = eventService.createEvent(dto, eventLocationEntity);
+        EventEntity result = eventService.createEvent(dto, eventLocationEntity);
 
         // then
         assertThat(result).extracting("eventName", "eventDescription", "date", "startTime")
-                .contains(responseDTO.getEventName(), responseDTO.getEventDescription(), responseDTO.getDate(), responseDTO.getStartTime());
+                .contains(eventEntity.getEventName(), eventEntity.getEventDescription(), eventEntity.getDate(),eventEntity.getStartTime());
         assertThat(result).extracting("eventLocationResponseDTO")
-                .isEqualTo(new EventLocationResponseDTO(eventLocationEntity));
+                .isEqualTo(eventLocationEntity);
     }
 
     @DisplayName("수정하고 싶은 이벤트 정보를 수정하면, 수정된 정보가 나온다.")
@@ -162,7 +153,6 @@ class EventServiceTest {
                 .build();
 
         eventEntity.update(dto, eventLocationEntitySuwon);
-        EventResponseDTO responseDTO = new EventResponseDTO(eventEntity);
 
         BDDMockito.given(eventRepository.findById(any(Long.class)))
                 .willReturn(Optional.of(eventEntity));
@@ -171,11 +161,11 @@ class EventServiceTest {
                 .willReturn(eventEntity);
 
         // when
-        EventResponseDTO result = eventService.updateEvent(1L, dto);
+        EventEntity result = eventService.updateEvent(1L, dto);
 
         // then
         assertThat(result).extracting("eventName", "eventDescription", "date", "startTime")
-                .contains(responseDTO.getEventName(), responseDTO.getEventDescription(), responseDTO.getDate(), responseDTO.getStartTime());
+                .contains(eventEntity.getEventName(), eventEntity.getEventDescription(), eventEntity.getDate(), eventEntity.getStartTime());
     }
 
     @DisplayName("삭제하고 싶은 이벤트를 삭제하고, 삭제된 이벤트 정보를 반환읋 한다.")
@@ -184,18 +174,17 @@ class EventServiceTest {
         // given
         EventLocationEntity eventLocationEntitySeoul = getEventLocationEntity(1L, "서울 월드컵 경기장");
         EventEntity eventEntity = getEventEntity(eventLocationEntitySeoul, "FC서울 vs 수원삼섬");
-        EventResponseDTO responseDTO = new EventResponseDTO(eventEntity);
 
         BDDMockito.given(eventRepository.findById(any(Long.class)))
                 .willReturn(Optional.of(eventEntity));
         BDDMockito.willDoNothing().given(eventRepository).delete(eventEntity);
 
         // when
-        EventResponseDTO result = eventService.deletedEvent(any(Long.class));
+        EventEntity result = eventService.deletedEvent(any(Long.class));
 
         // then
         assertThat(result).extracting("eventName", "eventDescription", "date", "startTime")
-                .contains(responseDTO.getEventName(), responseDTO.getEventDescription(), responseDTO.getDate(), responseDTO.getStartTime());
+                .contains(eventEntity.getEventName(), eventEntity.getEventDescription(), eventEntity.getDate(), eventEntity.getStartTime());
 
     }
 

--- a/src/test/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoServiceTest.java
@@ -1,0 +1,251 @@
+package github.ticketflow.domian.gradeTicketInfo;
+
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.event.dto.EventResponseDTO;
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoRequestDTO;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoResponseDTO;
+import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoUpdateRequestDTO;
+import github.ticketflow.domian.seat.SeatEntity;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import github.ticketflow.domian.seatGrade.dto.SeatGradeResponseDTO;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class GradeTicketInfoServiceTest {
+
+    @Mock
+    private GradeTicketInfoRepository gradeTicketInfoRepository;
+
+    @InjectMocks
+    private GradeTicketInfoService gradeTicketInfoService;
+
+    @DisplayName("등급별 좌석의 티켓의 정보의 id로 등급별 좌석의 티켓의 정보의 정보가 니온다.")
+    @Test
+    void getGradeTicketInfoByIdTest() {
+        // given
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        EventEntity eventEntity = getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
+        GradeTicketInfoEntity gradeTicketInfoEntity = gradeTicketInfoEntity(1L, eventEntity, seatGradeEntity);
+
+        BDDMockito.given(gradeTicketInfoRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(gradeTicketInfoEntity));
+
+        // when
+        GradeTicketInfoResponseDTO result = gradeTicketInfoService.getGradeTicketInfoById(gradeTicketInfoEntity.getGradeTicketInfoId());
+
+        // then
+        assertThat(result).extracting("numberTotalTicket", "numberOfRemainingTickets")
+                .contains(gradeTicketInfoEntity.getNumberTotalTicket(), gradeTicketInfoEntity.getNumberOfRemainingTickets());
+
+        assertThat(result.getEventResponseDTO()).isEqualTo(new EventResponseDTO(eventEntity));
+        assertThat(result.getEventResponseDTO().getEventLocationResponseDTO()).isEqualTo(new EventLocationResponseDTO(eventLocationEntity));
+        assertThat(result.getSeatGradeResponseDTO()).isEqualTo(new SeatGradeResponseDTO(seatGradeEntity));
+
+    }
+
+    @DisplayName("이벤트 엔티티로 등급별 티켓 정보를 검색하면, 리스트로 등급별 티켓 정보들이 나온다.")
+    @Test
+    void getGradeTicketInfoByEventEntityTest() {
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        EventEntity eventEntity = getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
+        SeatGradeEntity seatGradeEntity1 = getSeatGradeEntity(1L, eventLocationEntity);
+        SeatGradeEntity seatGradeEntity2 = getSeatGradeEntity(2L, eventLocationEntity);
+        SeatGradeEntity seatGradeEntity3 = getSeatGradeEntity(3L, eventLocationEntity);
+
+        GradeTicketInfoEntity gradeTicketInfoEntity1 = gradeTicketInfoEntity(1L, eventEntity, seatGradeEntity1);
+        GradeTicketInfoEntity gradeTicketInfoEntity2 = gradeTicketInfoEntity(1L, eventEntity, seatGradeEntity2);
+        GradeTicketInfoEntity gradeTicketInfoEntity3 = gradeTicketInfoEntity(1L, eventEntity, seatGradeEntity3);
+
+        List<GradeTicketInfoEntity> gradeTicketInfoEntities = List.of(gradeTicketInfoEntity1, gradeTicketInfoEntity2, gradeTicketInfoEntity3);
+
+        BDDMockito.given(gradeTicketInfoRepository.findAllByEventEntity(any(EventEntity.class)))
+                .willAnswer(invocationOnMock -> {
+                    Random random = new Random();
+                    int randomSize = random.nextInt(gradeTicketInfoEntities.size()) + 1;
+                    return gradeTicketInfoEntities.subList(0, randomSize);
+                });
+
+        // when
+        List<GradeTicketInfoResponseDTO> result = gradeTicketInfoService.getGradeTicketInfoByEventEntity(eventEntity);
+
+        // then
+        assertThat(result.size()).isBetween(1, 3);
+        assertThat(result).extracting("gradeTicketInfoId", "numberTotalTicket", "numberOfRemainingTickets")
+                .containsAnyOf(
+                        tuple(1L, gradeTicketInfoEntity1.getNumberTotalTicket(), gradeTicketInfoEntity1.getNumberOfRemainingTickets()),
+                        tuple(2L, gradeTicketInfoEntity2.getNumberTotalTicket(), gradeTicketInfoEntity2.getNumberOfRemainingTickets()),
+                        tuple(3L, gradeTicketInfoEntity3.getNumberTotalTicket(), gradeTicketInfoEntity3.getNumberOfRemainingTickets())
+                );
+    }
+
+    @DisplayName("이벤트 엔티티와 좌석 등급 엔티리로 등급별 좌석 정보를 가지고 오면 등급별 좌석 정보가 나온다.")
+    @Test
+    void getGradeTicketInfoByEventEntityAndSeatGradeEntityTest() {
+        // given
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        EventEntity eventEntity = getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
+        GradeTicketInfoEntity gradeTicketInfoEntity = gradeTicketInfoEntity(1L, eventEntity, seatGradeEntity);
+
+        BDDMockito.given(gradeTicketInfoRepository.findByEventEntityAndSeatGradeEntity(any(EventEntity.class), any(SeatGradeEntity.class)))
+                .willReturn(Optional.of(gradeTicketInfoEntity));
+
+        // when
+        GradeTicketInfoResponseDTO result = gradeTicketInfoService.getGradeTicketInfoByEventEntityAndSeatGradeEntity(eventEntity, seatGradeEntity);
+
+        // then
+        assertThat(result).extracting("numberTotalTicket", "numberOfRemainingTickets")
+                .contains(gradeTicketInfoEntity.getNumberTotalTicket(), gradeTicketInfoEntity.getNumberOfRemainingTickets());
+
+        assertThat(result.getEventResponseDTO()).isEqualTo(new EventResponseDTO(eventEntity));
+        assertThat(result.getEventResponseDTO().getEventLocationResponseDTO()).isEqualTo(new EventLocationResponseDTO(eventLocationEntity));
+        assertThat(result.getSeatGradeResponseDTO()).isEqualTo(new SeatGradeResponseDTO(seatGradeEntity));
+    }
+
+    @DisplayName("등급별 좌석 정보를 생성을 하면, 등급별 좌석 정보가 나온다.")
+    @Test
+    void createGradeTicketInfoTest() {
+        // given
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        EventEntity eventEntity = getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
+        GradeTicketInfoEntity gradeTicketInfoEntity = gradeTicketInfoEntity(1L, eventEntity, seatGradeEntity);
+
+        GradeTicketInfoRequestDTO dto = new GradeTicketInfoRequestDTO(eventEntity.getEventId(), seatGradeEntity.getSeatGradeId(), 120, 120);
+
+
+        BDDMockito.given(gradeTicketInfoRepository.save(any(GradeTicketInfoEntity.class)))
+                .willReturn(gradeTicketInfoEntity);
+
+        // when
+        GradeTicketInfoResponseDTO result = gradeTicketInfoService.createGradeTicketInfo(dto, eventEntity, eventEntity.getEventLocation(), seatGradeEntity);
+
+        // then
+        assertThat(result).extracting("numberTotalTicket", "numberOfRemainingTickets")
+                .contains(gradeTicketInfoEntity.getNumberTotalTicket(), gradeTicketInfoEntity.getNumberOfRemainingTickets());
+        assertThat(result.getEventResponseDTO()).isEqualTo(new EventResponseDTO(eventEntity));
+        assertThat(result.getEventResponseDTO().getEventLocationResponseDTO()).isEqualTo(new EventLocationResponseDTO(eventLocationEntity));
+        assertThat(result.getSeatGradeResponseDTO()).isEqualTo(new SeatGradeResponseDTO(seatGradeEntity));
+    }
+
+    @DisplayName("등급별 좌석 정보에 수정이 필요한 부분을 수정을 하면, 수정된 정보가 나온다.")
+    @Test
+    void updateGradeTicketInfoTest() {
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        EventEntity eventEntity = getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
+        GradeTicketInfoEntity gradeTicketInfoEntity = gradeTicketInfoEntity(1L, eventEntity, seatGradeEntity);
+
+        EventLocationEntity eventLocationEntitySuwon = getEventLocationEntity(2L, "수원 빅버드 경기장");
+        EventEntity eventEntity2 = getEventEntity(eventLocationEntitySuwon, "수원 삼성 VS 포항 스틸러스");
+        GradeTicketInfoUpdateRequestDTO dto = GradeTicketInfoUpdateRequestDTO.builder()
+                .eventId(2L)
+                .numberTotalTicket(150)
+                .numberOfRemainingTickets(150)
+                .build();
+
+        GradeTicketInfoUpdate update = GradeTicketInfoUpdate.builder()
+                .eventEntity(eventEntity2)
+                .build();
+
+        GradeTicketInfoEntity updateGradeTicketInfoEntity = gradeTicketInfoEntity.update(dto, update);
+
+        BDDMockito.given(gradeTicketInfoRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(gradeTicketInfoEntity));
+
+        BDDMockito.given(gradeTicketInfoRepository.save(any(GradeTicketInfoEntity.class)))
+                .willReturn(updateGradeTicketInfoEntity);
+
+        // then
+        GradeTicketInfoResponseDTO result = gradeTicketInfoService.updateGradeTicketInfo(gradeTicketInfoEntity.getGradeTicketInfoId(), dto, update);
+
+        // then
+        assertThat(result).extracting("numberTotalTicket", "numberOfRemainingTickets")
+                .contains(updateGradeTicketInfoEntity.getNumberTotalTicket(), updateGradeTicketInfoEntity.getNumberOfRemainingTickets());
+        assertThat(result.getEventResponseDTO()).isEqualTo(new EventResponseDTO(eventEntity2));
+        assertThat(result.getEventResponseDTO().getEventLocationResponseDTO()).isEqualTo(new EventLocationResponseDTO(eventLocationEntitySuwon));
+    }
+
+    @DisplayName("등급별 좌석 정보를 삭제를 하면, 삭제된 등급별 좌석 정보가 나온다.")
+    @Test
+    void deleteGradeTicketInfoTest() {
+        // given
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        EventEntity eventEntity = getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
+        GradeTicketInfoEntity gradeTicketInfoEntity = gradeTicketInfoEntity(1L, eventEntity, seatGradeEntity);
+
+        BDDMockito.given(gradeTicketInfoRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(gradeTicketInfoEntity));
+
+        BDDMockito.willDoNothing().given(gradeTicketInfoRepository).delete(any(GradeTicketInfoEntity.class));
+
+        // when
+        GradeTicketInfoResponseDTO result = gradeTicketInfoService.deleteGradeTicketInfo(gradeTicketInfoEntity.getGradeTicketInfoId());
+
+        // then
+        assertThat(result).extracting("numberTotalTicket", "numberOfRemainingTickets")
+                .contains(gradeTicketInfoEntity.getNumberTotalTicket(), gradeTicketInfoEntity.getNumberOfRemainingTickets());
+        assertThat(result.getEventResponseDTO()).isEqualTo(new EventResponseDTO(eventEntity));
+        assertThat(result.getEventResponseDTO().getEventLocationResponseDTO()).isEqualTo(new EventLocationResponseDTO(eventLocationEntity));
+        assertThat(result.getSeatGradeResponseDTO()).isEqualTo(new SeatGradeResponseDTO(seatGradeEntity));
+    }
+
+    private static EventEntity getEventEntity(EventLocationEntity eventLocationEntity, String eventName) {
+        return EventEntity.builder()
+                .eventId(1L)
+                .eventLocation(eventLocationEntity)
+                .eventName(eventName)
+                .eventDescription("축구 경기")
+                .date(LocalDate.of(2024, 10, 15))
+                .startTime(LocalTime.of(20, 30))
+                .build();
+    }
+
+    private static EventLocationEntity getEventLocationEntity(Long eventLocationId, String eventLocationName) {
+        return new EventLocationEntity(eventLocationId, eventLocationName, 50000);
+    }
+
+    private static SeatGradeEntity getSeatGradeEntity(Long seatGradeId, EventLocationEntity eventLocationEntity) {
+        return SeatGradeEntity.builder()
+                .seatGradeId(seatGradeId)
+                .eventLocation(eventLocationEntity)
+                .seatGradeName("1구역")
+                .seatGradePrice(BigDecimal.valueOf(100000))
+                .seatGradeTotalSeats(120)
+                .build();
+    }
+
+    private static GradeTicketInfoEntity gradeTicketInfoEntity(Long gradeTicketId, EventEntity eventEntity, SeatGradeEntity seatGradeEntity) {
+        return GradeTicketInfoEntity.builder()
+                .gradeTicketInfoId(gradeTicketId)
+                .eventEntity(eventEntity)
+                .eventLocationEntity(eventEntity.getEventLocation())
+                .seatGradeEntity(seatGradeEntity)
+                .numberTotalTicket(120)
+                .numberOfRemainingTickets(120)
+                .build();
+    }
+
+}

--- a/src/test/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoServiceTest.java
@@ -1,6 +1,5 @@
 package github.ticketflow.domian.gradeTicketInfo;
 
-import github.ticketflow.domian.Fixture;
 import github.ticketflow.domian.event.EventEntity;
 import github.ticketflow.domian.event.dto.EventResponseDTO;
 import github.ticketflow.domian.eventLocation.EventLocationEntity;
@@ -8,10 +7,8 @@ import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
 import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoRequestDTO;
 import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoResponseDTO;
 import github.ticketflow.domian.gradeTicketInfo.dto.GradeTicketInfoUpdateRequestDTO;
-import github.ticketflow.domian.seat.SeatEntity;
 import github.ticketflow.domian.seatGrade.SeatGradeEntity;
 import github.ticketflow.domian.seatGrade.dto.SeatGradeResponseDTO;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,9 +21,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
-import static github.ticketflow.domian.Fixture.*;
+import static github.ticketflow.domian.CommonTestFixture.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoServiceTest.java
@@ -138,7 +138,7 @@ class GradeTicketInfoServiceTest {
                 .willReturn(gradeTicketInfoEntity);
 
         // when
-        GradeTicketInfoResponseDTO result = gradeTicketInfoService.createGradeTicketInfo(dto, eventEntity, eventEntity.getEventLocation(), seatGradeEntity);
+        GradeTicketInfoResponseDTO result = gradeTicketInfoService.createGradeTicketInfo(dto, eventEntity, eventEntity.getEventLocationEntity(), seatGradeEntity);
 
         // then
         assertThat(result).extracting("numberTotalTicket", "numberOfRemainingTickets")

--- a/src/test/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/gradeTicketInfo/GradeTicketInfoServiceTest.java
@@ -1,5 +1,6 @@
 package github.ticketflow.domian.gradeTicketInfo;
 
+import github.ticketflow.domian.Fixture;
 import github.ticketflow.domian.event.EventEntity;
 import github.ticketflow.domian.event.dto.EventResponseDTO;
 import github.ticketflow.domian.eventLocation.EventLocationEntity;
@@ -19,13 +20,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
+import static github.ticketflow.domian.Fixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,7 +43,7 @@ class GradeTicketInfoServiceTest {
     void getGradeTicketInfoByIdTest() {
         // given
         EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
-        EventEntity eventEntity = getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
+        EventEntity eventEntity =  getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
         SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
         GradeTicketInfoEntity gradeTicketInfoEntity = gradeTicketInfoEntity(1L, eventEntity, seatGradeEntity);
 
@@ -211,41 +210,4 @@ class GradeTicketInfoServiceTest {
         assertThat(result.getEventResponseDTO().getEventLocationResponseDTO()).isEqualTo(new EventLocationResponseDTO(eventLocationEntity));
         assertThat(result.getSeatGradeResponseDTO()).isEqualTo(new SeatGradeResponseDTO(seatGradeEntity));
     }
-
-    private static EventEntity getEventEntity(EventLocationEntity eventLocationEntity, String eventName) {
-        return EventEntity.builder()
-                .eventId(1L)
-                .eventLocation(eventLocationEntity)
-                .eventName(eventName)
-                .eventDescription("축구 경기")
-                .date(LocalDate.of(2024, 10, 15))
-                .startTime(LocalTime.of(20, 30))
-                .build();
-    }
-
-    private static EventLocationEntity getEventLocationEntity(Long eventLocationId, String eventLocationName) {
-        return new EventLocationEntity(eventLocationId, eventLocationName, 50000);
-    }
-
-    private static SeatGradeEntity getSeatGradeEntity(Long seatGradeId, EventLocationEntity eventLocationEntity) {
-        return SeatGradeEntity.builder()
-                .seatGradeId(seatGradeId)
-                .eventLocation(eventLocationEntity)
-                .seatGradeName("1구역")
-                .seatGradePrice(BigDecimal.valueOf(100000))
-                .seatGradeTotalSeats(120)
-                .build();
-    }
-
-    private static GradeTicketInfoEntity gradeTicketInfoEntity(Long gradeTicketId, EventEntity eventEntity, SeatGradeEntity seatGradeEntity) {
-        return GradeTicketInfoEntity.builder()
-                .gradeTicketInfoId(gradeTicketId)
-                .eventEntity(eventEntity)
-                .eventLocationEntity(eventEntity.getEventLocation())
-                .seatGradeEntity(seatGradeEntity)
-                .numberTotalTicket(120)
-                .numberOfRemainingTickets(120)
-                .build();
-    }
-
 }

--- a/src/test/java/github/ticketflow/domian/seatGrade/SeatGradeServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/seatGrade/SeatGradeServiceTest.java
@@ -45,20 +45,19 @@ class SeatGradeServiceTest {
     void getSeatGradeByIdTest() {
         // given
         EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
-        EventLocationResponseDTO dto = new EventLocationResponseDTO(eventLocationEntity);
         SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
         BDDMockito.given(seatGradeRepository.findById(seatGradeEntity.getSeatGradeId()))
                 .willReturn(Optional.of(seatGradeEntity));
 
         // when
-        SeatGradeResponseDTO result = seatGradeService.getSeatGradeById(seatGradeEntity.getSeatGradeId());
+        SeatGradeEntity result = seatGradeService.getSeatGradeById(seatGradeEntity.getSeatGradeId());
 
         // then
         assertThat(result)
                 .extracting("seatGradeId", "seatGradeName", "seatGradePrice", "seatGradeTotalSeats")
                 .contains(1L, seatGradeEntity.getSeatGradeName(), seatGradeEntity.getSeatGradePrice(), seatGradeEntity.getSeatGradeTotalSeats());
 
-        assertThat(result.getEventLocation()).isEqualTo(dto);
+        assertThat(result.getEventLocation()).isEqualTo(eventLocationEntity);
     }
 
 
@@ -107,7 +106,6 @@ class SeatGradeServiceTest {
     void createSeatGradeTest() {
         // give
         EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
-        EventLocationResponseDTO dto = new EventLocationResponseDTO(eventLocationEntity);
         SeatGradeRequestDTO seatGradeRequestDTO = new SeatGradeRequestDTO(1L, "1등급", setBigDecimal(150000), 5000);
         SeatGradeEntity seatGradeEntity = new SeatGradeEntity(seatGradeRequestDTO, eventLocationEntity);
 
@@ -118,14 +116,14 @@ class SeatGradeServiceTest {
                 .willReturn(seatGradeEntity);
 
         // when
-        SeatGradeResponseDTO result = seatGradeService.createSeatGrade(seatGradeRequestDTO);
+        SeatGradeEntity result = seatGradeService.createSeatGrade(seatGradeRequestDTO);
 
         // then
         assertThat(result)
                 .extracting("seatGradeName", "seatGradePrice", "seatGradeTotalSeats")
                 .contains(seatGradeEntity.getSeatGradeName(), seatGradeEntity.getSeatGradePrice(), seatGradeEntity.getSeatGradeTotalSeats());
 
-        assertThat(result.getEventLocation()).isEqualTo(dto);
+        assertThat(result.getEventLocation()).isEqualTo(eventLocationEntity);
 
     }
 
@@ -150,7 +148,7 @@ class SeatGradeServiceTest {
                 .willReturn(seatGradeEntity);
 
         // when
-        SeatGradeResponseDTO result = seatGradeService.updateSeatGrade(seatGradeEntity.getSeatGradeId(), seatGradeUpdateRequestDTO);
+        SeatGradeEntity result = seatGradeService.updateSeatGrade(seatGradeEntity.getSeatGradeId(), seatGradeUpdateRequestDTO);
 
         // then
         assertThat(result)
@@ -164,21 +162,20 @@ class SeatGradeServiceTest {
         // given
         EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
         SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
-        EventLocationResponseDTO dto = new EventLocationResponseDTO(eventLocationEntity);
         BDDMockito.given(seatGradeRepository.findById(any(Long.class)))
                 .willReturn(Optional.of(seatGradeEntity));
 
         BDDMockito.willDoNothing().given(seatGradeRepository).delete(any(SeatGradeEntity.class));
 
         // when
-        SeatGradeResponseDTO result = seatGradeService.deletedSeatGrade(seatGradeEntity.getSeatGradeId());
+        SeatGradeEntity result = seatGradeService.deletedSeatGrade(seatGradeEntity.getSeatGradeId());
 
         // then
         assertThat(result)
                 .extracting("seatGradeId", "seatGradeName", "seatGradePrice", "seatGradeTotalSeats")
                 .contains(seatGradeEntity.getSeatGradeId(), seatGradeEntity.getSeatGradeName(), seatGradeEntity.getSeatGradePrice(), seatGradeEntity.getSeatGradeTotalSeats());
 
-        assertThat(result.getEventLocation()).isEqualTo(dto);
+        assertThat(result.getEventLocation()).isEqualTo(eventLocationEntity);
 
     }
 


### PR DESCRIPTION
### 요약
이벤트의 좌석 등급별로 정보가 담긴 엔티티를 만들고 CRUD 작성 후 테스트 코드를 작성하였습니다.

### 상세 설명
- 엔티티와 DTO (Request, Response, UpdateRequest)를 만들었습니다.
- Facade 패턴을 적용하였습니다.
- cotroller, facade, service, repository로 비지니스 로직을 작성하였습니다.
- 이에 대한 테스트 코드를 작성을 하였습니다.

### 관련 이슈
이 PR은 #26 이슈를 해결하기 위해서 진행되었습니다.

### 테스트
- 등급별 좌석의 정보의 CRUD의 테스트 코드를 작성을 하였습니다.