### PR TITLE
[Modify] 자주 쓰는 TestFixture를 CommonTestRFixture로 리팩토링

### DIFF
--- a/src/test/java/github/ticketflow/domian/event/EventServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/event/EventServiceTest.java
@@ -1,5 +1,6 @@
 package github.ticketflow.domian.event;
 
+import github.ticketflow.domian.CommonTestFixture;
 import github.ticketflow.domian.categoryEvent.CategoryEventEntity;
 import github.ticketflow.domian.category.CategoryEntity;
 import github.ticketflow.domian.event.dto.EventRequestDTO;
@@ -21,6 +22,8 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
+import static github.ticketflow.domian.CommonTestFixture.*;
+import static github.ticketflow.domian.CommonTestFixture.getEventEntity;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 
@@ -183,21 +186,5 @@ class EventServiceTest {
         assertThat(result).extracting("eventName", "eventDescription", "date", "startTime")
                 .contains(eventEntity.getEventName(), eventEntity.getEventDescription(), eventEntity.getDate(), eventEntity.getStartTime());
 
-    }
-
-    private static EventEntity getEventEntity(EventLocationEntity eventLocationEntity, String eventName) {
-        return EventEntity.builder()
-                .eventId(1L)
-                .eventLocationEntity(eventLocationEntity)
-                .eventName(eventName)
-                .eventDescription("축구 경기")
-                .date(LocalDate.of(2024, 10, 15))
-                .startTime(LocalTime.of(20, 30))
-                .build();
-    }
-
-    private static EventLocationEntity getEventLocationEntity(Long eventLocationId, String eventLocationName) {
-        EventLocationEntity eventLocationEntity = new EventLocationEntity(eventLocationId, eventLocationName, 50000);
-        return eventLocationEntity;
     }
 }

--- a/src/test/java/github/ticketflow/domian/eventLocation/EventLocationServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/eventLocation/EventLocationServiceTest.java
@@ -14,6 +14,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
+
+import static github.ticketflow.domian.CommonTestFixture.getEventLocationEntity;
 import static org.mockito.ArgumentMatchers.any;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -31,7 +33,7 @@ class EventLocationServiceTest {
     @Test
     void getEventLocationByIdTest() {
         // given
-        EventLocationEntity eventLocationEntity = new EventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울월드컵 경기장");
         BDDMockito.given(eventLocationRepository.findById(eventLocationEntity.getEventLocationId()))
                 .willReturn(Optional.of(eventLocationEntity));
 
@@ -65,7 +67,7 @@ class EventLocationServiceTest {
     @Test
     void updateEventLocationTest() {
         // given
-        EventLocationEntity eventLocationEntity = new EventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울월드컵 경기장");
         EventLocationUpdateRequestDTO dto = new EventLocationUpdateRequestDTO("빅버드 스타디움", 40000);
         EventLocationEntity updateEventLocationEntity = eventLocationEntity.update(dto);
 
@@ -89,7 +91,7 @@ class EventLocationServiceTest {
     @Test
     void deleteEventLocationTest() {
         // given
-        EventLocationEntity eventLocationEntity = new EventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        EventLocationEntity eventLocationEntity =  getEventLocationEntity(1L, "서울월드컵 경기장");
         BDDMockito.given(eventLocationRepository.findById(eventLocationEntity.getEventLocationId()))
                 .willReturn(Optional.of(eventLocationEntity));
         BDDMockito.willDoNothing().given(eventLocationRepository).delete(eventLocationEntity);

--- a/src/test/java/github/ticketflow/domian/seat/SeatServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/seat/SeatServiceTest.java
@@ -1,5 +1,6 @@
 package github.ticketflow.domian.seat;
 
+import github.ticketflow.domian.CommonTestFixture;
 import github.ticketflow.domian.eventLocation.EventLocationEntity;
 import github.ticketflow.domian.seat.dto.SeatRequestDTO;
 import github.ticketflow.domian.seat.dto.SeatResponseDTO;
@@ -23,6 +24,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
+import static github.ticketflow.domian.CommonTestFixture.getEventLocationEntity;
+import static github.ticketflow.domian.CommonTestFixture.getSeatGradeEntity;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,8 +47,8 @@ class SeatServiceTest {
     @Test
     public void getSeatByIdTest() {
         // given
-        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
         SeatEntity seatEntity = getSeatEntity(1L, seatGradeEntity, "1구역", 2, 25);
 
         BDDMockito.given(seatRepository.findById(any(Long.class)))
@@ -66,8 +69,8 @@ class SeatServiceTest {
     @Test
     void getSeatBySeatGradeTest() {
         // given
-        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
         SeatGradeResponseDTO dto = new SeatGradeResponseDTO(seatGradeEntity);
         SeatEntity seatEntity1 = getSeatEntity(1L, seatGradeEntity, "1구역", 2, 25);
         SeatEntity seatEntity2 = getSeatEntity(2L, seatGradeEntity, "1구역", 2, 26);
@@ -106,8 +109,8 @@ class SeatServiceTest {
     @Test
     void createSeatTest() {
         // given
-        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
         SeatRequestDTO seatRequestDTO = new SeatRequestDTO(seatGradeEntity.getSeatGradeId(),"1구역", 2, 25);
         SeatEntity seatEntity = new SeatEntity(seatRequestDTO, seatGradeEntity);
 
@@ -132,8 +135,8 @@ class SeatServiceTest {
     @Test
     void updateSeatTest() {
         // given
-        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
         SeatUpdateRequestDTO updateDTO = SeatUpdateRequestDTO.builder()
                 .seatRow(3)
                 .seatNumber(36)
@@ -161,8 +164,8 @@ class SeatServiceTest {
     @Test
     void deleteSeatTest() {
         // given
-        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
         SeatEntity seatEntity = getSeatEntity(1L, seatGradeEntity, "1구역", 2, 25);
         BDDMockito.given(seatRepository.findById(any(Long.class)))
                 .willReturn(Optional.of(seatEntity));
@@ -184,13 +187,4 @@ class SeatServiceTest {
     private static SeatEntity getSeatEntity(Long id, SeatGradeEntity seatGradeEntity, String seatZone, int seatRow ,int seatNumber) {
         return new SeatEntity(id, seatGradeEntity, seatZone, seatRow, seatNumber);
     }
-
-    private static EventLocationEntity getEventLocationEntity(Long id, String name, int totalSeats) {
-        return new EventLocationEntity(id, name, totalSeats);
-    }
-
-    private static SeatGradeEntity getSeatGradeEntity(Long id, EventLocationEntity eventLocationEntity, String seatGrade, int price, int seatGradeTotalSeats) {
-        return new SeatGradeEntity(id, eventLocationEntity, seatGrade, BigDecimal.valueOf(price), seatGradeTotalSeats);
-    }
-
 }

--- a/src/test/java/github/ticketflow/domian/seatGrade/SeatGradeServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/seatGrade/SeatGradeServiceTest.java
@@ -1,5 +1,6 @@
 package github.ticketflow.domian.seatGrade;
 
+import github.ticketflow.domian.CommonTestFixture;
 import github.ticketflow.domian.eventLocation.EventLocationEntity;
 import github.ticketflow.domian.eventLocation.EventLocationRepository;
 import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
@@ -22,6 +23,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
+import static github.ticketflow.domian.CommonTestFixture.*;
+import static github.ticketflow.domian.CommonTestFixture.getSeatGradeEntity;
 import static org.mockito.ArgumentMatchers.any;
 
 import static org.assertj.core.api.Assertions.*;
@@ -44,8 +47,8 @@ class SeatGradeServiceTest {
     @Test
     void getSeatGradeByIdTest() {
         // given
-        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
         BDDMockito.given(seatGradeRepository.findById(seatGradeEntity.getSeatGradeId()))
                 .willReturn(Optional.of(seatGradeEntity));
 
@@ -66,12 +69,12 @@ class SeatGradeServiceTest {
     @Test
     void getSeatGradeByEventLocationIdTest() {
         // give
-        EventLocationEntity eventLocationEntitySeoul = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        EventLocationEntity eventLocationEntitySeoul = getEventLocationEntity(1L, "서울 월드컵 경기장");
 
         EventLocationResponseDTO dto = new EventLocationResponseDTO(eventLocationEntitySeoul);
-        SeatGradeEntity seatGradeEntity1st = getSeatGradeEntity(1L, eventLocationEntitySeoul, "1등급", 150000, 20000);
-        SeatGradeEntity seatGradeEntity2nd = getSeatGradeEntity(2L, eventLocationEntitySeoul, "2등급", 100000, 30000);
-        SeatGradeEntity seatGradeEntity3rd = getSeatGradeEntity(3L, eventLocationEntitySeoul, "3등급", 50000, 30000);
+        SeatGradeEntity seatGradeEntity1st = getSeatGradeEntity(1L, eventLocationEntitySeoul);
+        SeatGradeEntity seatGradeEntity2nd = getSeatGradeEntity(2L, eventLocationEntitySeoul);
+        SeatGradeEntity seatGradeEntity3rd = getSeatGradeEntity(3L, eventLocationEntitySeoul);
         List<SeatGradeEntity> seatGradeEntities = new ArrayList<>(List.of(seatGradeEntity1st, seatGradeEntity2nd, seatGradeEntity3rd));
 
         BDDMockito.given(eventLocationRepository.findById(any(Long.class)))
@@ -105,7 +108,7 @@ class SeatGradeServiceTest {
     @Test
     void createSeatGradeTest() {
         // give
-        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
         SeatGradeRequestDTO seatGradeRequestDTO = new SeatGradeRequestDTO(1L, "1등급", setBigDecimal(150000), 5000);
         SeatGradeEntity seatGradeEntity = new SeatGradeEntity(seatGradeRequestDTO, eventLocationEntity);
 
@@ -131,8 +134,8 @@ class SeatGradeServiceTest {
     @Test
     void updateSeatGradeTest() {
         // given
-        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
 
         SeatGradeUpdateRequestDTO seatGradeUpdateRequestDTO = SeatGradeUpdateRequestDTO.builder()
                 .seatGradePrice(setBigDecimal(200000))
@@ -160,8 +163,8 @@ class SeatGradeServiceTest {
     @Test
     void deleteSeatGradeTest() {
         // given
-        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장", 50000);
-        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity, "1등급", 150000, 5000);
+        EventLocationEntity eventLocationEntity = getEventLocationEntity(1L, "서울 월드컵 경기장");
+        SeatGradeEntity seatGradeEntity = getSeatGradeEntity(1L, eventLocationEntity);
         BDDMockito.given(seatGradeRepository.findById(any(Long.class)))
                 .willReturn(Optional.of(seatGradeEntity));
 
@@ -179,16 +182,7 @@ class SeatGradeServiceTest {
 
     }
 
-    private static EventLocationEntity getEventLocationEntity(Long id, String name, int totalSeats) {
-        return new EventLocationEntity(id, name, totalSeats);
-    }
-
-    private static SeatGradeEntity getSeatGradeEntity(Long id, EventLocationEntity eventLocationEntity, String seatGrade, int price, int seatGradeTotalSeats) {
-        return new SeatGradeEntity(id, eventLocationEntity, seatGrade, BigDecimal.valueOf(price), seatGradeTotalSeats);
-    }
-
     private static BigDecimal setBigDecimal(int price) {
         return new BigDecimal(price);
     }
-
 }


### PR DESCRIPTION
### 요약
자주 쓰이는 TestFixture를 CommonTestFixture 클래스로 옮기고 리펙토링을 합니다.

### 상세 설명
- 자주 쓰이는 TestFixture를 CommonTestFixture에 분리를 했습니다.
- 테스트 코드에서 CommonTestFixture에서 TestFixture를 불러와서 사용하도록 리펙토링을 했습니다.

### 관련 이슈
이 PR은 #30 이슈를 해결하기 위해서 진행되었습니다.
