### PR TITLE
[Feat] 티켓 CRUD 기능 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/github/ticketflow/config/exception/ticket/TicketErrorResponsive.java
+++ b/src/main/java/github/ticketflow/config/exception/ticket/TicketErrorResponsive.java
@@ -14,11 +14,11 @@ public enum TicketErrorResponsive implements ErrorResponsive {
 
     @Override
     public HttpStatus getStatus() {
-        return null;
+        return status;
     }
 
     @Override
     public String getMessage() {
-        return "";
+        return message;
     }
 }

--- a/src/main/java/github/ticketflow/config/exception/ticket/TicketErrorResponsive.java
+++ b/src/main/java/github/ticketflow/config/exception/ticket/TicketErrorResponsive.java
@@ -1,0 +1,24 @@
+package github.ticketflow.config.exception.ticket;
+
+import github.ticketflow.config.exception.ErrorResponsive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum TicketErrorResponsive implements ErrorResponsive {
+    NOT_FOUND_TICKET(HttpStatus.NOT_FOUND, "티켓을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return "";
+    }
+}

--- a/src/main/java/github/ticketflow/domian/seat/SeatEntity.java
+++ b/src/main/java/github/ticketflow/domian/seat/SeatEntity.java
@@ -6,6 +6,7 @@ import github.ticketflow.domian.seat.dto.SeatUpdateRequestDTO;
 import github.ticketflow.domian.seatGrade.SeatGradeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +15,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Entity
 @Table(name = "Seat")
+@Builder
 public class SeatEntity {
 
     @Id

--- a/src/main/java/github/ticketflow/domian/ticket/TicketController.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketController.java
@@ -1,0 +1,51 @@
+package github.ticketflow.domian.ticket;
+
+import github.ticketflow.domian.ticket.dto.TicketRequestDTO;
+import github.ticketflow.domian.ticket.dto.TicketResponseDTO;
+import github.ticketflow.domian.ticket.dto.TicketUpdateRequestDTO;
+import jakarta.validation.Valid;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ticket")
+public class TicketController {
+
+    private final TicketFacade ticketFacade;
+
+    @GetMapping("/{ticketId}")
+    public ResponseEntity<TicketResponseDTO> getTicketById(@PathVariable Long ticketId) {
+        return ResponseEntity.ok(new TicketResponseDTO(ticketFacade.getTicketById(ticketId)));
+    }
+
+    @GetMapping("/{seatId}")
+    public ResponseEntity<TicketResponseDTO> getTicketBySeatEntity(@PathVariable Long seatId) {
+        return ResponseEntity.ok(new TicketResponseDTO(ticketFacade.getTicketBySeatEntity(seatId)));
+    }
+
+    @PostMapping
+    public ResponseEntity<TicketResponseDTO> createTicket(@Valid @RequestBody TicketRequestDTO dto) {
+        return ResponseEntity.ok(new TicketResponseDTO(ticketFacade.createTicket(dto)));
+    }
+
+    @PatchMapping("/{ticketId}")
+    public ResponseEntity<TicketResponseDTO> updateTicket(@PathVariable Long ticketId,
+                                                          @RequestBody TicketUpdateRequestDTO dto) {
+        return ResponseEntity.ok(new TicketResponseDTO(ticketFacade.updateTicket(ticketId, dto)));
+    }
+
+    @DeleteMapping("/{ticketId}")
+    public ResponseEntity<TicketResponseDTO> deleteTicket(@PathVariable Long ticketId) {
+        return ResponseEntity.ok(new TicketResponseDTO(ticketFacade.deleteTicket(ticketId)));
+    }
+}

--- a/src/main/java/github/ticketflow/domian/ticket/TicketEntity.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketEntity.java
@@ -84,11 +84,11 @@ public class TicketEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TicketEntity that = (TicketEntity) o;
-        return Objects.equals(ticketId, that.ticketId) && Objects.equals(eventEntity, that.eventEntity) && Objects.equals(seatEntity, that.seatEntity) && Objects.equals(ticketPrice, that.ticketPrice) && ticketStatus == that.ticketStatus && Objects.equals(createdAt, that.createdAt);
+        return Objects.equals(ticketId, that.ticketId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(ticketId, eventEntity, seatEntity, ticketPrice, ticketStatus, createdAt);
+        return Objects.hash(ticketId);
     }
 }

--- a/src/main/java/github/ticketflow/domian/ticket/TicketEntity.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketEntity.java
@@ -2,7 +2,6 @@ package github.ticketflow.domian.ticket;
 
 import github.ticketflow.domian.event.EventEntity;
 import github.ticketflow.domian.seat.SeatEntity;
-import github.ticketflow.domian.ticket.dto.TicketRequestDTO;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,7 +12,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -63,17 +61,17 @@ public class TicketEntity {
         this.ticketStatus = TicketStatus.NO_PAYMENT;
     }
 
-    public TicketEntity update(TicketUpdateClass ticketUpdateClass) {
-        if (ticketUpdateClass.getEventEntity() != null) {
-            this.eventEntity = ticketUpdateClass.getEventEntity();
+    public TicketEntity update(TicketUpdateVO ticketUpdateVO) {
+        if (ticketUpdateVO.getEventEntity() != null) {
+            this.eventEntity = ticketUpdateVO.getEventEntity();
 
         }
-        if(ticketUpdateClass.getSeatEntity() != null) {
-            this.seatEntity = ticketUpdateClass.getSeatEntity();
+        if(ticketUpdateVO.getSeatEntity() != null) {
+            this.seatEntity = ticketUpdateVO.getSeatEntity();
 
         }
-        if(ticketUpdateClass.getTicketPrice() != null) {
-            this.ticketPrice = ticketUpdateClass.getTicketPrice();
+        if(ticketUpdateVO.getTicketPrice() != null) {
+            this.ticketPrice = ticketUpdateVO.getTicketPrice();
 
         }
         return this;

--- a/src/main/java/github/ticketflow/domian/ticket/TicketEntity.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketEntity.java
@@ -1,0 +1,94 @@
+package github.ticketflow.domian.ticket;
+
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.seat.SeatEntity;
+import github.ticketflow.domian.ticket.dto.TicketRequestDTO;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "ticket")
+@Builder
+public class TicketEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long ticketId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id")
+    private EventEntity eventEntity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_id")
+    private SeatEntity seatEntity;
+
+    @Column(name = "ticket_price")
+    private BigDecimal ticketPrice;
+
+    @Column(name = "ticket_status")
+    @Enumerated(EnumType.STRING)
+    private TicketStatus ticketStatus;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDate createdAt;
+
+    public TicketEntity(EventEntity eventEntity, SeatEntity seatEntity, BigDecimal ticketPrice) {
+        this.eventEntity = eventEntity;
+        this.seatEntity = seatEntity;
+        this.ticketPrice = ticketPrice;
+        this.ticketStatus = TicketStatus.NO_PAYMENT;
+    }
+
+    public TicketEntity update(TicketUpdateClass ticketUpdateClass) {
+        if (ticketUpdateClass.getEventEntity() != null) {
+            this.eventEntity = ticketUpdateClass.getEventEntity();
+
+        }
+        if(ticketUpdateClass.getSeatEntity() != null) {
+            this.seatEntity = ticketUpdateClass.getSeatEntity();
+
+        }
+        if(ticketUpdateClass.getTicketPrice() != null) {
+            this.ticketPrice = ticketUpdateClass.getTicketPrice();
+
+        }
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TicketEntity that = (TicketEntity) o;
+        return Objects.equals(ticketId, that.ticketId) && Objects.equals(eventEntity, that.eventEntity) && Objects.equals(seatEntity, that.seatEntity) && Objects.equals(ticketPrice, that.ticketPrice) && ticketStatus == that.ticketStatus && Objects.equals(createdAt, that.createdAt);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ticketId, eventEntity, seatEntity, ticketPrice, ticketStatus, createdAt);
+    }
+}

--- a/src/main/java/github/ticketflow/domian/ticket/TicketFacade.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketFacade.java
@@ -33,22 +33,23 @@ public class TicketFacade {
     }
 
     public TicketEntity updateTicket(Long ticketId, TicketUpdateRequestDTO dto) {
-        TicketUpdateVO ticketUpdateVO = new TicketUpdateVO();
+        TicketUpdateVO.TicketUpdateVOBuilder builder = TicketUpdateVO.builder();
         if (dto.getEventId() != null) {
             EventEntity eventEntity = eventService.getEventById(dto.getEventId());
-            ticketUpdateVO.setEventEntity(eventEntity);
+            builder.eventEntity(eventEntity);
         }
         if (dto.getSeatId() != null) {
             SeatEntity seatEntity = seatService.getSeatById(dto.getSeatId());
-            ticketUpdateVO.setSeatEntity(seatEntity);
+            builder.seatEntity(seatEntity);
         }
         if (dto.getTicketPrice() != null) {
-            ticketUpdateVO.setTicketPrice(dto.getTicketPrice());
+            builder.ticketPrice(dto.getTicketPrice());
         }
         if (dto.getTicketStatus() != null) {
-            ticketUpdateVO.setTicketStatus(dto.getTicketStatus());
+            builder.ticketStatus(dto.getTicketStatus());
         }
 
+        TicketUpdateVO ticketUpdateVO = builder.build();
         return ticketService.updateTicket(ticketId, ticketUpdateVO);
     }
 

--- a/src/main/java/github/ticketflow/domian/ticket/TicketFacade.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketFacade.java
@@ -33,23 +33,23 @@ public class TicketFacade {
     }
 
     public TicketEntity updateTicket(Long ticketId, TicketUpdateRequestDTO dto) {
-        TicketUpdateClass ticketUpdateClass = new TicketUpdateClass();
+        TicketUpdateVO ticketUpdateVO = new TicketUpdateVO();
         if (dto.getEventId() != null) {
             EventEntity eventEntity = eventService.getEventById(dto.getEventId());
-            ticketUpdateClass.setEventEntity(eventEntity);
+            ticketUpdateVO.setEventEntity(eventEntity);
         }
         if (dto.getSeatId() != null) {
             SeatEntity seatEntity = seatService.getSeatById(dto.getSeatId());
-            ticketUpdateClass.setSeatEntity(seatEntity);
+            ticketUpdateVO.setSeatEntity(seatEntity);
         }
         if (dto.getTicketPrice() != null) {
-            ticketUpdateClass.setTicketPrice(dto.getTicketPrice());
+            ticketUpdateVO.setTicketPrice(dto.getTicketPrice());
         }
         if (dto.getTicketStatus() != null) {
-            ticketUpdateClass.setTicketStatus(dto.getTicketStatus());
+            ticketUpdateVO.setTicketStatus(dto.getTicketStatus());
         }
 
-        return ticketService.updateTicket(ticketId, ticketUpdateClass);
+        return ticketService.updateTicket(ticketId, ticketUpdateVO);
     }
 
     public TicketEntity deleteTicket(Long ticketId) {

--- a/src/main/java/github/ticketflow/domian/ticket/TicketFacade.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketFacade.java
@@ -1,0 +1,58 @@
+package github.ticketflow.domian.ticket;
+
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.event.EventService;
+import github.ticketflow.domian.seat.SeatEntity;
+import github.ticketflow.domian.seat.SeatService;
+import github.ticketflow.domian.ticket.dto.TicketRequestDTO;
+import github.ticketflow.domian.ticket.dto.TicketUpdateRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TicketFacade {
+
+    private final TicketService ticketService;
+    private final EventService eventService;
+    private final SeatService seatService;
+
+    public TicketEntity getTicketById(Long ticketId) {
+        return ticketService.getTicketById(ticketId);
+    }
+
+    public TicketEntity getTicketBySeatEntity(Long seatId) {
+        SeatEntity seatEntity = seatService.getSeatById(seatId);
+        return ticketService.getTicketBySeatEntity(seatEntity);
+    }
+
+    public TicketEntity createTicket(TicketRequestDTO dto) {
+        EventEntity eventEntity = eventService.getEventById(dto.getEventId());
+        SeatEntity seatEntity = seatService.getSeatById(dto.getSeatId());
+        return ticketService.createTicket(eventEntity, seatEntity, dto.getTicketPrice());
+    }
+
+    public TicketEntity updateTicket(Long ticketId, TicketUpdateRequestDTO dto) {
+        TicketUpdateClass ticketUpdateClass = new TicketUpdateClass();
+        if (dto.getEventId() != null) {
+            EventEntity eventEntity = eventService.getEventById(dto.getEventId());
+            ticketUpdateClass.setEventEntity(eventEntity);
+        }
+        if (dto.getSeatId() != null) {
+            SeatEntity seatEntity = seatService.getSeatById(dto.getSeatId());
+            ticketUpdateClass.setSeatEntity(seatEntity);
+        }
+        if (dto.getTicketPrice() != null) {
+            ticketUpdateClass.setTicketPrice(dto.getTicketPrice());
+        }
+        if (dto.getTicketStatus() != null) {
+            ticketUpdateClass.setTicketStatus(dto.getTicketStatus());
+        }
+
+        return ticketService.updateTicket(ticketId, ticketUpdateClass);
+    }
+
+    public TicketEntity deleteTicket(Long ticketId) {
+        return ticketService.deleteTicket(ticketId);
+    }
+}

--- a/src/main/java/github/ticketflow/domian/ticket/TicketRepository.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketRepository.java
@@ -1,0 +1,12 @@
+package github.ticketflow.domian.ticket;
+
+import github.ticketflow.domian.seat.SeatEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TicketRepository extends JpaRepository<TicketEntity, Long> {
+
+    Optional<TicketEntity> findBySeatEntity(SeatEntity seatEntity);
+
+}

--- a/src/main/java/github/ticketflow/domian/ticket/TicketService.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketService.java
@@ -30,9 +30,9 @@ public class TicketService {
         return ticketRepository.save(ticketEntity);
     }
 
-    public TicketEntity updateTicket(Long ticketId, TicketUpdateClass ticketUpdateClass) {
+    public TicketEntity updateTicket(Long ticketId, TicketUpdateVO ticketUpdateVO) {
         TicketEntity ticketEntity = getTicketById(ticketId);
-        TicketEntity updateTicketEntity = ticketEntity.update(ticketUpdateClass);
+        TicketEntity updateTicketEntity = ticketEntity.update(ticketUpdateVO);
         return ticketRepository.save(updateTicketEntity);
     }
 

--- a/src/main/java/github/ticketflow/domian/ticket/TicketService.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketService.java
@@ -1,0 +1,45 @@
+package github.ticketflow.domian.ticket;
+
+import github.ticketflow.config.exception.GlobalCommonException;
+import github.ticketflow.config.exception.ticket.TicketErrorResponsive;
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.seat.SeatEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class TicketService {
+
+    private final TicketRepository ticketRepository;
+
+    public TicketEntity getTicketById(Long ticketId) {
+        return ticketRepository.findById(ticketId).orElseThrow(() ->
+                new GlobalCommonException(TicketErrorResponsive.NOT_FOUND_TICKET));
+    }
+
+    public TicketEntity getTicketBySeatEntity(SeatEntity seatEntity) {
+        return  ticketRepository.findBySeatEntity(seatEntity).orElseThrow(() ->
+                new GlobalCommonException(TicketErrorResponsive.NOT_FOUND_TICKET));
+    }
+
+    public TicketEntity createTicket(EventEntity eventEntity, SeatEntity seatEntity, BigDecimal ticketPrice) {
+        TicketEntity ticketEntity = new TicketEntity(eventEntity, seatEntity, ticketPrice);
+        return ticketRepository.save(ticketEntity);
+    }
+
+    public TicketEntity updateTicket(Long ticketId, TicketUpdateClass ticketUpdateClass) {
+        TicketEntity ticketEntity = getTicketById(ticketId);
+        TicketEntity updateTicketEntity = ticketEntity.update(ticketUpdateClass);
+        return ticketRepository.save(updateTicketEntity);
+    }
+
+    public TicketEntity deleteTicket(Long ticketId) {
+        TicketEntity ticketEntity = getTicketById(ticketId);
+        ticketRepository.delete(ticketEntity);
+        return ticketEntity;
+    }
+
+}

--- a/src/main/java/github/ticketflow/domian/ticket/TicketStatus.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketStatus.java
@@ -1,0 +1,6 @@
+package github.ticketflow.domian.ticket;
+
+public enum TicketStatus {
+    NO_PAYMENT,
+    PAYMENT_SUCCESS,
+}

--- a/src/main/java/github/ticketflow/domian/ticket/TicketUpdateClass.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketUpdateClass.java
@@ -1,0 +1,32 @@
+package github.ticketflow.domian.ticket;
+
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.seat.SeatEntity;
+import github.ticketflow.domian.ticket.dto.TicketUpdateRequestDTO;
+import jakarta.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TicketUpdateClass {
+
+    @Nullable
+    private EventEntity eventEntity;
+    @Nullable
+    private SeatEntity seatEntity;
+    @Nullable
+    private BigDecimal ticketPrice;
+    @Nullable
+    private TicketStatus ticketStatus;
+
+
+}

--- a/src/main/java/github/ticketflow/domian/ticket/TicketUpdateVO.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketUpdateVO.java
@@ -12,7 +12,6 @@ import lombok.Setter;
 import java.math.BigDecimal;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/github/ticketflow/domian/ticket/TicketUpdateVO.java
+++ b/src/main/java/github/ticketflow/domian/ticket/TicketUpdateVO.java
@@ -2,7 +2,6 @@ package github.ticketflow.domian.ticket;
 
 import github.ticketflow.domian.event.EventEntity;
 import github.ticketflow.domian.seat.SeatEntity;
-import github.ticketflow.domian.ticket.dto.TicketUpdateRequestDTO;
 import jakarta.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,7 +16,7 @@ import java.math.BigDecimal;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class TicketUpdateClass {
+public class TicketUpdateVO {
 
     @Nullable
     private EventEntity eventEntity;

--- a/src/main/java/github/ticketflow/domian/ticket/dto/TicketRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/ticket/dto/TicketRequestDTO.java
@@ -1,0 +1,25 @@
+package github.ticketflow.domian.ticket.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketRequestDTO {
+
+    @NotNull
+    private Long eventId;
+    @NotNull
+    private Long seatId;
+    @NotNull
+    @Positive
+    private BigDecimal ticketPrice;
+
+}

--- a/src/main/java/github/ticketflow/domian/ticket/dto/TicketResponseDTO.java
+++ b/src/main/java/github/ticketflow/domian/ticket/dto/TicketResponseDTO.java
@@ -1,0 +1,34 @@
+package github.ticketflow.domian.ticket.dto;
+
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.seat.SeatEntity;
+import github.ticketflow.domian.ticket.TicketEntity;
+import github.ticketflow.domian.ticket.TicketStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketResponseDTO {
+
+    private Long ticketId;
+    private EventEntity eventEntity;
+    private SeatEntity seatEntity;
+    private BigDecimal ticketPrice;
+    private TicketStatus ticketStatus;
+    private LocalDate createdAt;
+
+    public TicketResponseDTO(TicketEntity ticketEntity) {
+        this.ticketId = ticketEntity.getTicketId();
+        this.eventEntity = ticketEntity.getEventEntity();
+        this.seatEntity = ticketEntity.getSeatEntity();
+        this.ticketPrice = ticketEntity.getTicketPrice();
+        this.ticketStatus = ticketEntity.getTicketStatus();
+        this.createdAt = ticketEntity.getCreatedAt();
+    }
+}

--- a/src/main/java/github/ticketflow/domian/ticket/dto/TicketUpdateRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/ticket/dto/TicketUpdateRequestDTO.java
@@ -1,0 +1,20 @@
+package github.ticketflow.domian.ticket.dto;
+
+import github.ticketflow.domian.ticket.TicketStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketUpdateRequestDTO {
+
+    private Long eventId;
+    private Long seatId;
+    private BigDecimal ticketPrice;
+    private TicketStatus ticketStatus;
+
+}

--- a/src/test/java/github/ticketflow/domian/CommonTestFixture.java
+++ b/src/test/java/github/ticketflow/domian/CommonTestFixture.java
@@ -3,7 +3,10 @@ package github.ticketflow.domian;
 import github.ticketflow.domian.event.EventEntity;
 import github.ticketflow.domian.eventLocation.EventLocationEntity;
 import github.ticketflow.domian.gradeTicketInfo.GradeTicketInfoEntity;
+import github.ticketflow.domian.seat.SeatEntity;
 import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import github.ticketflow.domian.ticket.TicketEntity;
+import github.ticketflow.domian.ticket.TicketStatus;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -47,4 +50,23 @@ public class CommonTestFixture {
                 .build();
     }
 
+    public static SeatEntity getSeatEntity(Long seatId, SeatGradeEntity seatGradeEntity) {
+        return SeatEntity.builder()
+                .seatId(seatId)
+                .seatGradeEntity(seatGradeEntity)
+                .seatZone("1구역")
+                .seatRow(1)
+                .seatNumber(1)
+                .build();
+    }
+
+    public static TicketEntity getTicketEntity(Long ticketId, EventEntity eventEntity, SeatEntity seatEntity, BigDecimal price) {
+        return TicketEntity.builder()
+                .ticketId(1L)
+                .eventEntity(eventEntity)
+                .seatEntity(seatEntity)
+                .ticketPrice(price)
+                .ticketStatus(TicketStatus.NO_PAYMENT)
+                .build();
+    }
 }

--- a/src/test/java/github/ticketflow/domian/ticket/TicketServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/ticket/TicketServiceTest.java
@@ -1,0 +1,156 @@
+package github.ticketflow.domian.ticket;
+
+import github.ticketflow.domian.CommonTestFixture;
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.seat.SeatEntity;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class TicketServiceTest {
+
+    @Mock
+    private TicketRepository ticketRepository;
+
+    @InjectMocks
+    private TicketService ticketService;
+
+    @DisplayName("티켓의 id로 티켓을 조회하면, 티켓의 정보가 나온다.")
+    @Test
+    void getTicketByIdTest() {
+        // given
+        EventLocationEntity eventLocationEntity = CommonTestFixture.getEventLocationEntity(1L, "서울 월드컵 경기장");
+        EventEntity eventEntity = CommonTestFixture.getEventEntity(eventLocationEntity, "FC서울 vs 수원 삼성");
+        SeatGradeEntity seatGradeEntity = CommonTestFixture.getSeatGradeEntity(1L, eventLocationEntity);
+        SeatEntity seatEntity = CommonTestFixture.getSeatEntity(1L, seatGradeEntity);
+        TicketEntity ticketEntity = CommonTestFixture.getTicketEntity(1L, eventEntity, seatEntity, intToBigDecimal(1000000));
+
+        BDDMockito.given(ticketRepository.findById(any(Long.class)))
+                .willReturn(Optional.ofNullable(ticketEntity));
+
+        // when
+        TicketEntity result = ticketService.getTicketById(ticketEntity.getTicketId());
+
+        // then
+        assertThat(result).isEqualTo(ticketEntity);
+        assertThat(result).extracting("ticketPrice", "ticketStatus")
+                .contains(ticketEntity.getTicketPrice(), ticketEntity.getTicketStatus());
+
+    }
+
+    @DisplayName("좌석 엔티티로 조회를 하면, 티켓의 정보가 나온다.")
+    @Test
+    void getTicketBySeatEntityTest() {
+        // given
+        EventLocationEntity eventLocationEntity = CommonTestFixture.getEventLocationEntity(1L, "서울 월드컵 경기장");
+        EventEntity eventEntity = CommonTestFixture.getEventEntity(eventLocationEntity, "FC서울 vs 수원 삼성");
+        SeatGradeEntity seatGradeEntity = CommonTestFixture.getSeatGradeEntity(1L, eventLocationEntity);
+        SeatEntity seatEntity = CommonTestFixture.getSeatEntity(1L, seatGradeEntity);
+        TicketEntity ticketEntity = CommonTestFixture.getTicketEntity(1L, eventEntity, seatEntity, intToBigDecimal(1000000));
+
+        BDDMockito.given(ticketRepository.findBySeatEntity(any(SeatEntity.class)))
+                .willReturn(Optional.ofNullable(ticketEntity));
+
+        // when
+        TicketEntity result = ticketService.getTicketBySeatEntity(seatEntity);
+
+        // then
+        assertThat(result).isEqualTo(ticketEntity);
+        assertThat(result).extracting("ticketPrice", "ticketStatus")
+                .contains(ticketEntity.getTicketPrice(), ticketEntity.getTicketStatus());
+    }
+
+    @DisplayName("티켓을 생성을 하면, 티켓의 정보가 나온다.")
+    @Test
+    void createTicketTest() {
+        // given
+        EventLocationEntity eventLocationEntity = CommonTestFixture.getEventLocationEntity(1L, "서울 월드컵 경기장");
+        EventEntity eventEntity = CommonTestFixture.getEventEntity(eventLocationEntity, "FC서울 vs 수원 삼성");
+        SeatGradeEntity seatGradeEntity = CommonTestFixture.getSeatGradeEntity(1L, eventLocationEntity);
+        SeatEntity seatEntity = CommonTestFixture.getSeatEntity(1L, seatGradeEntity);
+        TicketEntity ticketEntity = CommonTestFixture.getTicketEntity(1L, eventEntity, seatEntity, intToBigDecimal(1000000));
+
+        BDDMockito.given(ticketRepository.save(any(TicketEntity.class)))
+                .willReturn(ticketEntity);
+
+        // when
+        TicketEntity result = ticketService.createTicket(eventEntity, seatEntity, ticketEntity.getTicketPrice());
+
+        // then
+        assertThat(result).isEqualTo(ticketEntity);
+        assertThat(result).extracting("ticketPrice", "ticketStatus")
+                .contains(ticketEntity.getTicketPrice(), ticketEntity.getTicketStatus());
+    }
+
+    @DisplayName("티켓을 수정을 하면, 수정된 정보가 나온다.")
+    @Test
+    void updateTicketTest() {
+        // given
+        EventLocationEntity eventLocationEntity = CommonTestFixture.getEventLocationEntity(1L, "서울 월드컵 경기장");
+        EventEntity eventEntity = CommonTestFixture.getEventEntity(eventLocationEntity, "FC서울 vs 수원 삼성");
+        SeatGradeEntity seatGradeEntity = CommonTestFixture.getSeatGradeEntity(1L, eventLocationEntity);
+        SeatEntity seatEntity = CommonTestFixture.getSeatEntity(1L, seatGradeEntity);
+        TicketEntity ticketEntity = CommonTestFixture.getTicketEntity(1L, eventEntity, seatEntity, intToBigDecimal(1000000));
+
+        TicketUpdateClass updateClass = TicketUpdateClass.builder()
+                .ticketPrice(intToBigDecimal(300000))
+                .build();
+
+        BDDMockito.given(ticketRepository.findById(any(Long.class)))
+                .willReturn(Optional.ofNullable(ticketEntity));
+
+        BDDMockito.given(ticketRepository.save(any(TicketEntity.class)))
+                .willReturn(ticketEntity);
+
+        // then
+        TicketEntity result = ticketService.updateTicket(ticketEntity.ticketId, updateClass);
+
+        // then
+        assertThat(result).isEqualTo(ticketEntity);
+        assertThat(result.getTicketPrice()).isEqualTo(updateClass.getTicketPrice());
+    }
+
+    @DisplayName("티켓을 삭제하면, 삭제된 정보가 나온다.")
+    @Test
+    void deleteTicketTest() {
+        // given
+        EventLocationEntity eventLocationEntity = CommonTestFixture.getEventLocationEntity(1L, "서울 월드컵 경기장");
+        EventEntity eventEntity = CommonTestFixture.getEventEntity(eventLocationEntity, "FC서울 vs 수원 삼성");
+        SeatGradeEntity seatGradeEntity = CommonTestFixture.getSeatGradeEntity(1L, eventLocationEntity);
+        SeatEntity seatEntity = CommonTestFixture.getSeatEntity(1L, seatGradeEntity);
+        TicketEntity ticketEntity = CommonTestFixture.getTicketEntity(1L, eventEntity, seatEntity, intToBigDecimal(1000000));
+
+        BDDMockito.given(ticketRepository.findById(any(Long.class)))
+                .willReturn(Optional.ofNullable(ticketEntity));
+
+        BDDMockito.willDoNothing().given(ticketRepository).delete(any(TicketEntity.class));
+
+        // when
+        TicketEntity result = ticketService.deleteTicket(ticketEntity.ticketId);
+
+        // then
+        assertThat(result).isEqualTo(ticketEntity);
+        assertThat(result).extracting("ticketPrice", "ticketStatus")
+                .contains(ticketEntity.getTicketPrice(), ticketEntity.getTicketStatus());
+    }
+
+    private BigDecimal intToBigDecimal(int price) {
+        return BigDecimal.valueOf(price);
+    }
+
+}

--- a/src/test/java/github/ticketflow/domian/ticket/TicketServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/ticket/TicketServiceTest.java
@@ -5,7 +5,6 @@ import github.ticketflow.domian.event.EventEntity;
 import github.ticketflow.domian.eventLocation.EventLocationEntity;
 import github.ticketflow.domian.seat.SeatEntity;
 import github.ticketflow.domian.seatGrade.SeatGradeEntity;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +17,6 @@ import java.math.BigDecimal;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
@@ -107,7 +105,7 @@ class TicketServiceTest {
         SeatEntity seatEntity = CommonTestFixture.getSeatEntity(1L, seatGradeEntity);
         TicketEntity ticketEntity = CommonTestFixture.getTicketEntity(1L, eventEntity, seatEntity, intToBigDecimal(1000000));
 
-        TicketUpdateClass updateClass = TicketUpdateClass.builder()
+        TicketUpdateVO updateClass = TicketUpdateVO.builder()
                 .ticketPrice(intToBigDecimal(300000))
                 .build();
 


### PR DESCRIPTION
### 요약
티켓 CRUD의 기능을 구현을 하고 이에 대한 테스트 코드를 작성을 하였습니다.

### 상세 설명
- Ticket Etity, DTO, Repository, Controller를 생성을 했습니다.
- 많은 Repository가 관련이 되어 있어서 Facade 패턴을 적용을 했습니다.
- 수정을 하는 부분에 Entity가 있기 때문에 TicketUpdateClass를 만들어서 관리를 했습니다.

### 관련 이슈
이 #32 이슈를 해결하기 위해서 진행되었습니다.

### 테스트
- 티켓의 CRUD에 대한 테스트를 진행을 했습니다.
- Mock을 사용해서 행위에 대해서 테스트를 했습니다.