### PR TITLE
[Feat] 결제 및 결제 티켓 CRUD 기능 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/github/ticketflow/config/exception/paymemtTicket/PaymentTicketErrorResponsive.java
+++ b/src/main/java/github/ticketflow/config/exception/paymemtTicket/PaymentTicketErrorResponsive.java
@@ -1,0 +1,24 @@
+package github.ticketflow.config.exception.paymemtTicket;
+
+import github.ticketflow.config.exception.ErrorResponsive;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum PaymentTicketErrorResponsive implements ErrorResponsive {
+    NOT_FOUND_PAYMENT_TICKET(HttpStatus.NOT_FOUND, "결제한 티켓의 맵핑된 엔티티를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/github/ticketflow/config/exception/payment/PaymentErrorResponsive.java
+++ b/src/main/java/github/ticketflow/config/exception/payment/PaymentErrorResponsive.java
@@ -1,0 +1,23 @@
+package github.ticketflow.config.exception.payment;
+
+import github.ticketflow.config.exception.ErrorResponsive;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum PaymentErrorResponsive implements ErrorResponsive {
+    NOT_FOUND_PAYMENT(HttpStatus.NOT_FOUND, "결제를 한 내역을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/github/ticketflow/domian/payment/PaymentController.java
+++ b/src/main/java/github/ticketflow/domian/payment/PaymentController.java
@@ -1,0 +1,46 @@
+package github.ticketflow.domian.payment;
+
+import github.ticketflow.domian.payment.dto.PaymentRequestDTO;
+import github.ticketflow.domian.payment.dto.PaymentResponseDTO;
+import jakarta.validation.Valid;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/payment")
+public class PaymentController {
+
+    private final PaymentFacade paymentFacade;
+
+    @GetMapping("/{paymentId}")
+    public ResponseEntity<PaymentResponseDTO> getPaymentById(@PathVariable Long paymentId) {
+        return ResponseEntity.ok(new PaymentResponseDTO(paymentFacade.getPaymentById(paymentId)));
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<PaymentResponseDTO>> getPaymentByUserEntity(@PathVariable Long userId) {
+        return ResponseEntity.ok(paymentFacade.getPaymentByUserEntity(userId));
+    }
+
+    @PostMapping
+    public ResponseEntity<PaymentResponseDTO> createPayment(@Valid @RequestBody PaymentRequestDTO dto) {
+        return ResponseEntity.ok(new PaymentResponseDTO(paymentFacade.createPayment(dto)));
+    }
+
+    @DeleteMapping("/{paymentId}")
+    public ResponseEntity<PaymentResponseDTO> deletePayment(@PathVariable Long paymentId) {
+        return ResponseEntity.ok(new PaymentResponseDTO(paymentFacade.deletedPayment(paymentId)));
+    }
+
+}

--- a/src/main/java/github/ticketflow/domian/payment/PaymentEntity.java
+++ b/src/main/java/github/ticketflow/domian/payment/PaymentEntity.java
@@ -1,0 +1,70 @@
+package github.ticketflow.domian.payment;
+
+import github.ticketflow.domian.payment.dto.PaymentRequestDTO;
+import github.ticketflow.domian.paymentTicket.PaymentTicketEntity;
+import github.ticketflow.domian.user.entity.UserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "Payment")
+@Builder
+public class PaymentEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long paymentId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity userEntity;
+
+    @Column(name = "number_of_ticket")
+    private int numberOfTicket;
+
+    @Column(name = "payment_price")
+    private BigDecimal paymentPrice;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDate createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDate deletedAt;
+
+    @OneToMany(mappedBy = "paymentEntity", fetch = FetchType.LAZY)
+    private List<PaymentTicketEntity> paymentTickets;
+
+    public PaymentEntity(PaymentVO paymentVO) {
+        this.userEntity = paymentVO.getUserEntity();
+        this.numberOfTicket = paymentVO.getNumberOfTicket();
+        this.paymentPrice = paymentVO.getPaymentPrice();
+    }
+
+    public PaymentEntity update(LocalDate deletedAt) {
+        this.deletedAt = deletedAt;
+        return this;
+    }
+
+}

--- a/src/main/java/github/ticketflow/domian/payment/PaymentFacade.java
+++ b/src/main/java/github/ticketflow/domian/payment/PaymentFacade.java
@@ -1,0 +1,68 @@
+package github.ticketflow.domian.payment;
+
+import github.ticketflow.domian.payment.dto.PaymentRequestDTO;
+import github.ticketflow.domian.payment.dto.PaymentResponseDTO;
+import github.ticketflow.domian.paymentTicket.PaymentTicketEntity;
+import github.ticketflow.domian.paymentTicket.PaymentTicketService;
+import github.ticketflow.domian.paymentTicket.PaymentTicketVO;
+import github.ticketflow.domian.ticket.TicketEntity;
+import github.ticketflow.domian.ticket.TicketService;
+import github.ticketflow.domian.user.UserService;
+import github.ticketflow.domian.user.entity.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentFacade {
+
+    private final PaymentService paymentService;
+    private final PaymentTicketService paymentTicketService;
+    private final TicketService ticketService;
+    private final UserService userService;
+
+
+    public PaymentEntity getPaymentById(Long paymentId) {
+        return paymentService.getPaymentById(paymentId);
+    }
+
+    public List<PaymentResponseDTO> getPaymentByUserEntity(Long userId) {
+        UserEntity userEntity = userService.getUserById(userId);
+        return paymentService.getPaymentByUserEntity(userEntity);
+    }
+
+    @Transactional
+    public PaymentEntity createPayment(PaymentRequestDTO dto) {
+        List<TicketEntity> ticketEntities = new ArrayList<>();
+
+        UserEntity userEntity = userService.getUserById(dto.getUserId());
+        dto.getTicketIds().forEach(ticketId -> {
+            ticketEntities.add(ticketService.getTicketById(ticketId));
+        });
+
+        PaymentVO paymentVO = new PaymentVO(userEntity, ticketEntities, dto);
+        PaymentEntity paymentEntity = paymentService.createPayment(paymentVO);
+
+        ticketEntities.forEach(ticketEntity -> {
+            PaymentTicketVO paymentTicketVO = new PaymentTicketVO(paymentEntity, ticketEntity);
+            paymentTicketService.createPaymentTicket(paymentTicketVO);
+        });
+
+        return paymentEntity;
+    }
+
+
+    public PaymentEntity deletedPayment(Long paymentId) {
+        PaymentEntity paymentEntity = getPaymentById(paymentId);
+        List<PaymentTicketEntity> paymentTickets = paymentEntity.getPaymentTickets();
+        paymentTickets.forEach((paymentTicket) -> {
+            paymentTicketService.deletedPaymentTicket(paymentId);
+        });
+        paymentService.deletedPayment(paymentId);
+        return paymentEntity;
+    }
+}

--- a/src/main/java/github/ticketflow/domian/payment/PaymentFacade.java
+++ b/src/main/java/github/ticketflow/domian/payment/PaymentFacade.java
@@ -55,7 +55,7 @@ public class PaymentFacade {
         return paymentEntity;
     }
 
-
+    @Transactional
     public PaymentEntity deletedPayment(Long paymentId) {
         PaymentEntity paymentEntity = getPaymentById(paymentId);
         List<PaymentTicketEntity> paymentTickets = paymentEntity.getPaymentTickets();

--- a/src/main/java/github/ticketflow/domian/payment/PaymentRepository.java
+++ b/src/main/java/github/ticketflow/domian/payment/PaymentRepository.java
@@ -1,0 +1,13 @@
+package github.ticketflow.domian.payment;
+
+import github.ticketflow.domian.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<PaymentEntity, Long> {
+
+    List<PaymentEntity> findByUserEntity(UserEntity userEntity);
+
+}

--- a/src/main/java/github/ticketflow/domian/payment/PaymentService.java
+++ b/src/main/java/github/ticketflow/domian/payment/PaymentService.java
@@ -1,0 +1,58 @@
+package github.ticketflow.domian.payment;
+
+import github.ticketflow.config.exception.GlobalCommonException;
+import github.ticketflow.config.exception.payment.PaymentErrorResponsive;
+import github.ticketflow.domian.payment.dto.PaymentRequestDTO;
+import github.ticketflow.domian.payment.dto.PaymentResponseDTO;
+import github.ticketflow.domian.user.entity.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+
+    public PaymentEntity getPaymentById(Long paymentId) {
+        return paymentRepository.findById(paymentId).orElseThrow(()->
+                new GlobalCommonException(PaymentErrorResponsive.NOT_FOUND_PAYMENT));
+    }
+
+    public List<PaymentResponseDTO> getPaymentByUserEntity(UserEntity userEntity) {
+        List<PaymentResponseDTO> paymentResponseDTOS = new ArrayList<>();
+
+        paymentRepository.findByUserEntity(userEntity).forEach(paymentEntity -> {
+            PaymentResponseDTO paymentResponseDTO = new PaymentResponseDTO(paymentEntity);
+            paymentResponseDTOS.add(paymentResponseDTO);
+        });
+
+        return paymentResponseDTOS;
+    }
+
+    public PaymentEntity createPayment(PaymentVO paymentVO) {
+        PaymentEntity paymentEntity = new PaymentEntity(paymentVO);
+        return paymentRepository.save(paymentEntity);
+    }
+
+    public PaymentEntity updatePayment(Long paymentId) {
+        PaymentEntity paymentEntity = getPaymentById(paymentId);
+        LocalDate deletedAt = LocalDate.now();
+        paymentEntity.update(deletedAt);
+
+        return paymentRepository.save(paymentEntity);
+    }
+
+    public PaymentEntity deletedPayment(Long paymentId) {
+        PaymentEntity paymentEntity = getPaymentById(paymentId);
+        paymentRepository.delete(paymentEntity);
+
+        return paymentEntity;
+    }
+
+
+}

--- a/src/main/java/github/ticketflow/domian/payment/PaymentVO.java
+++ b/src/main/java/github/ticketflow/domian/payment/PaymentVO.java
@@ -3,6 +3,9 @@ package github.ticketflow.domian.payment;
 import github.ticketflow.domian.payment.dto.PaymentRequestDTO;
 import github.ticketflow.domian.ticket.TicketEntity;
 import github.ticketflow.domian.user.entity.UserEntity;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,9 +18,13 @@ import java.util.List;
 @AllArgsConstructor
 public class PaymentVO {
 
+    @NotNull
     private UserEntity userEntity;
-    private int numberOfTicket;
+    @Positive
+    private Integer numberOfTicket;
+    @NotNull
     private List<TicketEntity> ticketEntities;
+    @NotNull
     private BigDecimal paymentPrice;
 
     public PaymentVO(UserEntity userEntity, List<TicketEntity> ticketEntities, PaymentRequestDTO dto) {

--- a/src/main/java/github/ticketflow/domian/payment/PaymentVO.java
+++ b/src/main/java/github/ticketflow/domian/payment/PaymentVO.java
@@ -1,0 +1,29 @@
+package github.ticketflow.domian.payment;
+
+import github.ticketflow.domian.payment.dto.PaymentRequestDTO;
+import github.ticketflow.domian.ticket.TicketEntity;
+import github.ticketflow.domian.user.entity.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentVO {
+
+    private UserEntity userEntity;
+    private int numberOfTicket;
+    private List<TicketEntity> ticketEntities;
+    private BigDecimal paymentPrice;
+
+    public PaymentVO(UserEntity userEntity, List<TicketEntity> ticketEntities, PaymentRequestDTO dto) {
+        this.userEntity = userEntity;
+        this.numberOfTicket = dto.getNumberOfTicket();
+        this.ticketEntities = ticketEntities;
+        this.paymentPrice = dto.getPaymentPrice();
+    }
+}

--- a/src/main/java/github/ticketflow/domian/payment/dto/PaymentRequestDTO.java
+++ b/src/main/java/github/ticketflow/domian/payment/dto/PaymentRequestDTO.java
@@ -1,0 +1,28 @@
+package github.ticketflow.domian.payment.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentRequestDTO {
+
+    @NotNull
+    private Long userId;
+    @Positive
+    private int numberOfTicket;
+    @NotNull
+    private List<Long> ticketIds;
+    @NotNull
+    private BigDecimal paymentPrice;
+
+}

--- a/src/main/java/github/ticketflow/domian/payment/dto/PaymentResponseDTO.java
+++ b/src/main/java/github/ticketflow/domian/payment/dto/PaymentResponseDTO.java
@@ -1,0 +1,43 @@
+package github.ticketflow.domian.payment.dto;
+
+import github.ticketflow.domian.payment.PaymentEntity;
+import github.ticketflow.domian.paymentTicket.PaymentTicketEntity;
+import github.ticketflow.domian.ticket.dto.TicketResponseDTO;
+import github.ticketflow.domian.user.dto.UserResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentResponseDTO {
+
+    private Long paymentId;
+    private UserResponseDTO userResponseDTO;
+    private int numberOfTicket;
+    private BigDecimal paymentPrice;
+    private List<TicketResponseDTO> tickets;
+    private LocalDate createdAt;
+
+    public PaymentResponseDTO(PaymentEntity paymentEntity) {
+        this.paymentId = paymentEntity.getPaymentId();
+        this.userResponseDTO = new UserResponseDTO(paymentEntity.getUserEntity());
+        this.numberOfTicket = paymentEntity.getNumberOfTicket();
+        this.paymentPrice = paymentEntity.getPaymentPrice();
+        this.tickets = paymentEntity.getPaymentTickets() != null ? paymentEntity.getPaymentTickets()
+                .stream()
+                .map(PaymentTicketEntity::getTicketEntity)
+                .map(TicketResponseDTO::new)
+                .collect(Collectors.toList()) : new ArrayList<>();
+        this.createdAt = paymentEntity.getCreatedAt();
+    }
+}

--- a/src/main/java/github/ticketflow/domian/paymentTicket/PaymentTicketEntity.java
+++ b/src/main/java/github/ticketflow/domian/paymentTicket/PaymentTicketEntity.java
@@ -1,0 +1,43 @@
+package github.ticketflow.domian.paymentTicket;
+
+import github.ticketflow.domian.payment.PaymentEntity;
+import github.ticketflow.domian.ticket.TicketEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "PaymentTicket")
+@Builder
+public class PaymentTicketEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_ticket_id")
+    private Long paymentTicketId;
+
+    @ManyToOne
+    @JoinColumn(name = "payment_id")
+    private PaymentEntity paymentEntity;
+
+    @ManyToOne
+    @JoinColumn(name = "ticket_id")
+    private TicketEntity ticketEntity;
+
+    public PaymentTicketEntity(PaymentTicketVO paymentTicketVO) {
+        this.paymentEntity = paymentTicketVO.getPaymentEntity();
+        this.ticketEntity = paymentTicketVO.getTicketEntity();
+    }
+}

--- a/src/main/java/github/ticketflow/domian/paymentTicket/PaymentTicketRepository.java
+++ b/src/main/java/github/ticketflow/domian/paymentTicket/PaymentTicketRepository.java
@@ -1,0 +1,6 @@
+package github.ticketflow.domian.paymentTicket;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentTicketRepository extends JpaRepository<PaymentTicketEntity, Long> {
+}

--- a/src/main/java/github/ticketflow/domian/paymentTicket/PaymentTicketService.java
+++ b/src/main/java/github/ticketflow/domian/paymentTicket/PaymentTicketService.java
@@ -1,0 +1,30 @@
+package github.ticketflow.domian.paymentTicket;
+
+import github.ticketflow.config.exception.GlobalCommonException;
+import github.ticketflow.config.exception.payment.PaymentErrorResponsive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.crossstore.ChangeSetPersister;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentTicketService {
+
+    private final PaymentTicketRepository paymentTicketRepository;
+
+    public PaymentTicketEntity getPaymentTicketById(Long paymentTicketId) {
+        return paymentTicketRepository.findById(paymentTicketId).orElseThrow(() ->
+                new GlobalCommonException(PaymentErrorResponsive.NOT_FOUND_PAYMENT));
+    }
+
+    public PaymentTicketEntity createPaymentTicket(PaymentTicketVO paymentTicketVO) {
+        PaymentTicketEntity paymentTicketEntity = new PaymentTicketEntity(paymentTicketVO);
+        return paymentTicketRepository.save(paymentTicketEntity);
+    }
+
+    public PaymentTicketEntity deletedPaymentTicket(Long paymentTicketId) {
+        PaymentTicketEntity paymentTicketEntity = getPaymentTicketById(paymentTicketId);
+        paymentTicketRepository.delete(paymentTicketEntity);
+        return paymentTicketEntity;
+    }
+}

--- a/src/main/java/github/ticketflow/domian/paymentTicket/PaymentTicketVO.java
+++ b/src/main/java/github/ticketflow/domian/paymentTicket/PaymentTicketVO.java
@@ -1,0 +1,19 @@
+package github.ticketflow.domian.paymentTicket;
+
+import github.ticketflow.domian.payment.PaymentEntity;
+import github.ticketflow.domian.ticket.TicketEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentTicketVO {
+
+    private PaymentEntity paymentEntity;
+    private TicketEntity ticketEntity;
+
+}

--- a/src/main/java/github/ticketflow/domian/user/UserService.java
+++ b/src/main/java/github/ticketflow/domian/user/UserService.java
@@ -18,6 +18,11 @@ public class UserService {
     private final UserRepository userRepository;
     private final LeaveUserRepository leaveUserRepository;
 
+    public UserEntity getUserById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() ->
+                new GlobalCommonException(AuthErrorResponsive.NOT_FOUND_USER));
+    }
+
     public UserEntity updateUser(Long userId, UserUpdateRequestDTO dto) {
         UserEntity userEntity = userRepository
                 .findById(userId)

--- a/src/test/java/github/ticketflow/domian/CommonTestFixture.java
+++ b/src/test/java/github/ticketflow/domian/CommonTestFixture.java
@@ -3,14 +3,18 @@ package github.ticketflow.domian;
 import github.ticketflow.domian.event.EventEntity;
 import github.ticketflow.domian.eventLocation.EventLocationEntity;
 import github.ticketflow.domian.gradeTicketInfo.GradeTicketInfoEntity;
+import github.ticketflow.domian.payment.PaymentEntity;
+import github.ticketflow.domian.paymentTicket.PaymentTicketEntity;
 import github.ticketflow.domian.seat.SeatEntity;
 import github.ticketflow.domian.seatGrade.SeatGradeEntity;
 import github.ticketflow.domian.ticket.TicketEntity;
 import github.ticketflow.domian.ticket.TicketStatus;
+import github.ticketflow.domian.user.entity.UserEntity;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 public class CommonTestFixture {
 
@@ -33,8 +37,8 @@ public class CommonTestFixture {
         return SeatGradeEntity.builder()
                 .seatGradeId(seatGradeId)
                 .eventLocation(eventLocationEntity)
-                .seatGradeName("1구역")
-                .seatGradePrice(BigDecimal.valueOf(100000))
+                .seatGradeName("1등급")
+                .seatGradePrice(BigDecimal.valueOf(10000))
                 .seatGradeTotalSeats(120)
                 .build();
     }
@@ -69,4 +73,30 @@ public class CommonTestFixture {
                 .ticketStatus(TicketStatus.NO_PAYMENT)
                 .build();
     }
+
+    public static UserEntity getUserEntity(Long userId) {
+        return UserEntity.builder()
+                .id(userId)
+                .email("test@test.com")
+                .password("dltkdgur12")
+                .phoneNumber("01011223344")
+                .build();
+    }
+
+    public static PaymentEntity getPaymentEntity(Long paymentId, UserEntity userEntity) {
+        return PaymentEntity.builder()
+                .paymentId(paymentId)
+                .userEntity(userEntity)
+                .numberOfTicket(1)
+                .paymentPrice(BigDecimal.valueOf(10000))
+                .build();
+    }
+
+    public static PaymentTicketEntity getPaymentTicketEntity(PaymentEntity paymentEntity, TicketEntity ticketEntity) {
+        return PaymentTicketEntity.builder()
+                .paymentEntity(paymentEntity)
+                .ticketEntity(ticketEntity)
+                .build();
+    }
+
 }

--- a/src/test/java/github/ticketflow/domian/payment/PaymentServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/payment/PaymentServiceTest.java
@@ -1,0 +1,174 @@
+package github.ticketflow.domian.payment;
+
+import github.ticketflow.domian.CommonTestFixture;
+import github.ticketflow.domian.event.EventEntity;
+import github.ticketflow.domian.eventLocation.EventLocationEntity;
+import github.ticketflow.domian.payment.dto.PaymentRequestDTO;
+import github.ticketflow.domian.payment.dto.PaymentResponseDTO;
+import github.ticketflow.domian.paymentTicket.PaymentTicketEntity;
+import github.ticketflow.domian.seat.SeatEntity;
+import github.ticketflow.domian.seatGrade.SeatGradeEntity;
+import github.ticketflow.domian.ticket.TicketEntity;
+import github.ticketflow.domian.user.entity.UserEntity;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    @DisplayName("결제의 아이디를 가지고 조회를 하면, 티켓의 정보가 나온다.")
+    @Test
+    void getPaymentById() {
+        // given
+        UserEntity userEntity = CommonTestFixture.getUserEntity(1L);
+        EventLocationEntity eventLocationEntity = CommonTestFixture.getEventLocationEntity(1L, "사울 월드컵 경기장");
+        EventEntity eventEntity = CommonTestFixture.getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
+        SeatGradeEntity seatGradeEntity = CommonTestFixture.getSeatGradeEntity(1L, eventLocationEntity);
+        SeatEntity seatEntity = CommonTestFixture.getSeatEntity(1L, seatGradeEntity);
+        TicketEntity ticketEntity = CommonTestFixture.getTicketEntity(1L, eventEntity, seatEntity, BigDecimal.valueOf(10000));
+        PaymentEntity paymentEntity = CommonTestFixture.getPaymentEntity(1L, userEntity);
+        PaymentTicketEntity paymentTicketEntity = CommonTestFixture.getPaymentTicketEntity(paymentEntity, ticketEntity);
+
+        BDDMockito.given(paymentRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(paymentEntity));
+
+
+        // when
+        PaymentEntity result = paymentService.getPaymentById(paymentEntity.getPaymentId());
+
+        // then
+        assertThat(result).extracting("numberOfTicket", "paymentPrice")
+                .contains(paymentEntity.getNumberOfTicket(), paymentEntity.getPaymentPrice());
+    }
+
+    @DisplayName("유저의 엔티티로 티켓의 정보를 가지고 온다.")
+    @Test
+    void getPaymentByUserEntity() {
+        // given
+        UserEntity userEntity = CommonTestFixture.getUserEntity(1L);
+        EventLocationEntity eventLocationEntity = CommonTestFixture.getEventLocationEntity(1L, "사울 월드컵 경기장");
+        EventEntity eventEntity = CommonTestFixture.getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
+        SeatGradeEntity seatGradeEntity = CommonTestFixture.getSeatGradeEntity(1L, eventLocationEntity);
+        SeatEntity seatEntity = CommonTestFixture.getSeatEntity(1L, seatGradeEntity);
+        TicketEntity ticketEntity = CommonTestFixture.getTicketEntity(1L, eventEntity, seatEntity, BigDecimal.valueOf(10000));
+        PaymentEntity paymentEntity = CommonTestFixture.getPaymentEntity(1L, userEntity);
+        PaymentTicketEntity paymentTicketEntity = CommonTestFixture.getPaymentTicketEntity(paymentEntity, ticketEntity);
+
+        BDDMockito.given(paymentRepository.findByUserEntity(any(UserEntity.class)))
+                .willReturn(List.of(paymentEntity));
+
+        // when
+        List<PaymentResponseDTO> result = paymentService.getPaymentByUserEntity(userEntity);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).extracting("numberOfTicket", "paymentPrice")
+                .contains(paymentEntity.getNumberOfTicket(), paymentEntity.getPaymentPrice());
+    }
+
+    @DisplayName("결제를 생성하면 생성된 정보가 나온다.")
+    @Test
+    void createPayment() {
+        // given
+        UserEntity userEntity = CommonTestFixture.getUserEntity(1L);
+        EventLocationEntity eventLocationEntity = CommonTestFixture.getEventLocationEntity(1L, "사울 월드컵 경기장");
+        EventEntity eventEntity = CommonTestFixture.getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
+        SeatGradeEntity seatGradeEntity = CommonTestFixture.getSeatGradeEntity(1L, eventLocationEntity);
+        SeatEntity seatEntity = CommonTestFixture.getSeatEntity(1L, seatGradeEntity);
+        TicketEntity ticketEntity = CommonTestFixture.getTicketEntity(1L, eventEntity, seatEntity, BigDecimal.valueOf(10000));
+        PaymentEntity paymentEntity = CommonTestFixture.getPaymentEntity(1L, userEntity);
+        PaymentTicketEntity paymentTicketEntity = CommonTestFixture.getPaymentTicketEntity(paymentEntity, ticketEntity);
+
+        PaymentRequestDTO dto = new PaymentRequestDTO(1L, 1, List.of(1L), BigDecimal.valueOf(10000));
+        PaymentVO paymentVO = new PaymentVO(userEntity, List.of(ticketEntity), dto);
+
+        BDDMockito.given(paymentRepository.save(any(PaymentEntity.class)))
+                .willReturn(paymentEntity);
+
+        // when
+        PaymentEntity result = paymentService.createPayment(paymentVO);
+
+        // then
+        assertThat(result).extracting("numberOfTicket", "paymentPrice")
+                .contains(paymentEntity.getNumberOfTicket(), paymentEntity.getPaymentPrice());
+    }
+
+    @DisplayName("수정하기를 했을 떄, deletedAt에 변경된 값이 나온다.")
+    @Test
+    void updatePaymentTest() {
+        // given
+        UserEntity userEntity = CommonTestFixture.getUserEntity(1L);
+        EventLocationEntity eventLocationEntity = CommonTestFixture.getEventLocationEntity(1L, "사울 월드컵 경기장");
+        EventEntity eventEntity = CommonTestFixture.getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
+        SeatGradeEntity seatGradeEntity = CommonTestFixture.getSeatGradeEntity(1L, eventLocationEntity);
+        SeatEntity seatEntity = CommonTestFixture.getSeatEntity(1L, seatGradeEntity);
+        TicketEntity ticketEntity = CommonTestFixture.getTicketEntity(1L, eventEntity, seatEntity, BigDecimal.valueOf(10000));
+        PaymentEntity paymentEntity = CommonTestFixture.getPaymentEntity(1L, userEntity);
+        PaymentTicketEntity paymentTicketEntity = CommonTestFixture.getPaymentTicketEntity(paymentEntity, ticketEntity);
+
+        LocalDate deletedAt = LocalDate.of(2024, 10, 4);
+
+        PaymentEntity updatePaymentEntity = paymentEntity.update(deletedAt);
+
+        BDDMockito.given(paymentRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(paymentEntity));
+
+        BDDMockito.given(paymentRepository.save(any(PaymentEntity.class)))
+                .willReturn(updatePaymentEntity);
+
+        // when
+        PaymentEntity result = paymentService.updatePayment(paymentEntity.getPaymentId());
+
+        // then
+        assertThat(result).extracting("deletedAt").isEqualTo(updatePaymentEntity.getDeletedAt());
+    }
+
+    @DisplayName("결제 정보를 삭제를 하면, 삭제된 정보가 나온다.")
+    @Test
+    void deletePaymentTest() {
+        // given
+        UserEntity userEntity = CommonTestFixture.getUserEntity(1L);
+        EventLocationEntity eventLocationEntity = CommonTestFixture.getEventLocationEntity(1L, "사울 월드컵 경기장");
+        EventEntity eventEntity = CommonTestFixture.getEventEntity(eventLocationEntity, "FC서울 VS 수원 삼성");
+        SeatGradeEntity seatGradeEntity = CommonTestFixture.getSeatGradeEntity(1L, eventLocationEntity);
+        SeatEntity seatEntity = CommonTestFixture.getSeatEntity(1L, seatGradeEntity);
+        TicketEntity ticketEntity = CommonTestFixture.getTicketEntity(1L, eventEntity, seatEntity, BigDecimal.valueOf(10000));
+        PaymentEntity paymentEntity = CommonTestFixture.getPaymentEntity(1L, userEntity);
+        PaymentTicketEntity paymentTicketEntity = CommonTestFixture.getPaymentTicketEntity(paymentEntity, ticketEntity);
+
+        BDDMockito.given(paymentRepository.findById(any(Long.class)))
+                .willReturn(Optional.of(paymentEntity));
+
+        BDDMockito.willDoNothing().given(paymentRepository).delete(any(PaymentEntity.class));
+
+        // when
+        PaymentEntity result = paymentService.deletedPayment(paymentEntity.getPaymentId());
+
+        // then
+        assertThat(result).extracting("numberOfTicket", "paymentPrice")
+                .contains(paymentEntity.getNumberOfTicket(), paymentEntity.getPaymentPrice());
+    }
+
+}


### PR DESCRIPTION
### 요약
결제의 CRUD와 결제와 티켓의 맵핑 테이블을 만들었고 결제에 대한 테스트 코드를 작성을 했습니다.

### 상세 설명
- 결제에 대한 CRUD의 기능을 구현을 했습니다.
- 결제가 되면 결제와 티켓의 맵핑테이블의 결제티켓 엔티티를 만들어 저장을 하였습니다.
- 결제 내역을 조회을 하면 결제한 티켓의 정보가 같이 나옵니다.
- 결제 CRUD에 대한 테스트를 했습니다.

### 관련 이슈
이 PR은 #34 이슈를 해결하기 위해서 진행되었습니다.

### 테스트
- 결제 서비스에 대한 테스트를 진행을 했습니다,