### PR TITLE
 [Feat] 인기 검색어 Spring JVM 메모리로 구현

### DIFF
--- a/src/main/java/github/ticketflow/config/CacheConfig.java
+++ b/src/main/java/github/ticketflow/config/CacheConfig.java
@@ -1,0 +1,9 @@
+package github.ticketflow.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+}

--- a/src/main/java/github/ticketflow/domian/event/EventController.java
+++ b/src/main/java/github/ticketflow/domian/event/EventController.java
@@ -28,6 +28,11 @@ public class EventController {
         return ResponseEntity.ok(eventFacade.getEventByCategoryId(categoryId, pageNo));
     }
 
+    @GetMapping("/{eventName}")
+    public ResponseEntity<List<EventResponseDTO>> getEventByEventName(@PathVariable String eventName) {
+        return ResponseEntity.ok(eventFacade.getEventByEventName(eventName));
+    }
+
     @PostMapping
     public ResponseEntity<EventResponseDTO> createEvent(@Valid @RequestBody EventRequestDTO dto) {
         return ResponseEntity.ok(new EventResponseDTO(eventFacade.createEvent(dto)));

--- a/src/main/java/github/ticketflow/domian/event/EventFacade.java
+++ b/src/main/java/github/ticketflow/domian/event/EventFacade.java
@@ -11,6 +11,7 @@ import github.ticketflow.domian.event.dto.EventUpdateRequestDTO;
 import github.ticketflow.domian.eventLocation.EventLocationEntity;
 import github.ticketflow.domian.eventLocation.EventLocationService;
 import github.ticketflow.domian.eventLocation.dto.EventLocationResponseDTO;
+import github.ticketflow.domian.popularSearch.PopularSearchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
@@ -27,6 +28,7 @@ public class EventFacade {
     private final EventLocationService eventLocationService;
     private final CategoryEventService categoryEventService;
     private final DeletedEventService deletedEventService;
+    private final PopularSearchService popularSearchService;
 
     EventEntity getEventById(Long eventId) {
         return  eventService.getEventById(eventId);
@@ -38,6 +40,11 @@ public class EventFacade {
 
         Page<CategoryEventEntity> categoryEventEntities = categoryEventService.getCategoryEventsByCategory(categoryEntity, page);
         return eventService.getEventByCategoryId(categoryEventEntities);
+    }
+
+    List<EventResponseDTO> getEventByEventName (String eventName) {
+        popularSearchService.incrementKeywordCount(eventName);
+        return eventService.getEventByEventName(eventName);
     }
 
     @Transactional

--- a/src/main/java/github/ticketflow/domian/event/EventRepository.java
+++ b/src/main/java/github/ticketflow/domian/event/EventRepository.java
@@ -2,5 +2,10 @@ package github.ticketflow.domian.event;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface EventRepository extends JpaRepository<EventEntity, Long> {
+
+    List<EventEntity> findAllByEventNameContainingIgnoreCase(String eventName);
+
 }

--- a/src/main/java/github/ticketflow/domian/event/EventService.java
+++ b/src/main/java/github/ticketflow/domian/event/EventService.java
@@ -36,6 +36,15 @@ public class EventService {
         return eventEntities;
     }
 
+    public List<EventResponseDTO> getEventByEventName(String eventName) {
+        List<EventResponseDTO> eventEntities = new ArrayList<>();
+        eventRepository.findAllByEventNameContainingIgnoreCase(eventName).forEach(
+                eventEntity -> eventEntities.add(new EventResponseDTO(eventEntity))
+        );
+
+        return eventEntities;
+    }
+
     public EventEntity createEvent(EventRequestDTO dto,
                                    EventLocationEntity eventLocationEntity) {
         EventEntity newEventEntity = new EventEntity(dto, eventLocationEntity);

--- a/src/main/java/github/ticketflow/domian/popularSearch/PopularSearchController.java
+++ b/src/main/java/github/ticketflow/domian/popularSearch/PopularSearchController.java
@@ -1,0 +1,29 @@
+package github.ticketflow.domian.popularSearch;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/popularSearch")
+public class PopularSearchController {
+
+    private final PopularSearchService popularSearchService;
+
+    @GetMapping
+    public List<String> getPopularSearch() {
+        return popularSearchService.getPopularKeywords(10);
+    }
+
+    @Scheduled(fixedRate = 3600000)
+    public void updatePopularKeywords() {
+        List<String> popularKeywords = popularSearchService.getPopularKeywords(10);
+    }
+
+}

--- a/src/main/java/github/ticketflow/domian/popularSearch/PopularSearchService.java
+++ b/src/main/java/github/ticketflow/domian/popularSearch/PopularSearchService.java
@@ -2,7 +2,6 @@ package github.ticketflow.domian.popularSearch;
 
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -33,8 +32,4 @@ public class PopularSearchService {
     public void resetKeywords() {
         keywordCount.clear();
     }
-
-
-
-
 }

--- a/src/main/java/github/ticketflow/domian/popularSearch/PopularSearchService.java
+++ b/src/main/java/github/ticketflow/domian/popularSearch/PopularSearchService.java
@@ -1,0 +1,40 @@
+package github.ticketflow.domian.popularSearch;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+@Service
+public class PopularSearchService {
+
+    private final Map<String, Long> keywordCount = new HashMap<>();
+
+    public void incrementKeywordCount(String keyword) {
+        keywordCount.merge(keyword, 1L, Long::sum);
+    }
+
+    @Cacheable(value = "popularKeywords", key = "#limit")
+    public List<String> getPopularKeywords(int limit) {
+        return keywordCount.entrySet().stream()
+                .sorted((e1, e2) -> e2.getValue().compareTo(e1.getValue()))
+                .limit(limit)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+
+    @CacheEvict(value = "popularKeyword", allEntries = true)
+    public void resetKeywords() {
+        keywordCount.clear();
+    }
+
+
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,9 @@ spring:
 ---
 
 spring:
+  cache:
+    caffeine:
+      spec: expireAfterWrite=10m, maximumSize=1000
   config:
     activate:
       on-profile: test

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,12 +2,12 @@ spring:
   profiles:
     default: local
 
-
-
-
 ---
 
 spring:
+  cache:
+    caffeine:
+      spec: expireAfterWrite=10m, maximumSize=1000
   config:
     activate:
       on-profile: local

--- a/src/test/java/github/ticketflow/domian/popularSearch/PopularSearchServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/popularSearch/PopularSearchServiceTest.java
@@ -1,0 +1,44 @@
+package github.ticketflow.domian.popularSearch;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PopularSearchServiceTest {
+
+    @Autowired
+    private PopularSearchService popularSearchService;
+
+    @DisplayName("검색어가 저장이 되고 인기 검색어를 불러오면 리스트로 나온다.")
+    @Test
+    void getPopularKeywordsTest() {
+        // give
+        popularSearchService.incrementKeywordCount("서울");
+        popularSearchService.incrementKeywordCount("수원");
+        popularSearchService.incrementKeywordCount("수원");
+        popularSearchService.incrementKeywordCount("서울");
+        popularSearchService.incrementKeywordCount("수원");
+
+        // when
+        List<String> result = popularSearchService.getPopularKeywords(10);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0)).isEqualTo("수원");
+        assertThat(result.get(1)).isEqualTo("서울");
+    }
+
+
+}


### PR DESCRIPTION
### 요약
인기 검색어 메모리로 구현을 하고 테스트를 진행을 했습니다.

### 상세 설명
- 인기 검색어를 Spring 메모리로 구현을 했습니다.
- event 검색하는 비지니스 로직을 구현을 했습니다.
- 검색을 할 때, 인기 검색어 맵에 카운트를 올리도록 했습니다.
- 카운트별로 정렬를 해서 인기 검색어를 가지고 옵니다.
- 인기 검색어를 캐싱을 해서 빠르게 결과를 가지고 옵니다.
- 캐싱은 최대 10분으로 잡았고 10분 뒤에 다시 검색을 하면 새로 캐싱이 됩니다.
- 그리고 인기 검색어 맵은 1시간 뒤 리셋을 합니다.

### 관련 이슈
이 PR은 #38 이슈를 해결하기 위해서 진행되었습니다.

### 테스트
-가짜 객체를 만들 필요가 없고 메소드 두 개를 사용해야 해서 SpringBootTest를 활용을 해서 진행을 했습니다.