### PR TITLE
[Feat] 좌석 선택하기 동시성 제어

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     // Test
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     runtimeOnly 'com.h2database:h2'
+    testImplementation 'org.mockito:mockito-core'
+
 
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -55,6 +57,11 @@ dependencies {
 
     // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // redis
+    // redisson
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.20.0'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,12 @@ services:
       test: ["CMD", "mysqladmin", "ping"]
       interval: 5s
       retries: 10
+
+  my-cache-server:
+    image: redis
+    ports:
+      - 6379:6379
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      retries: 10

--- a/src/main/java/github/ticketflow/config/RedissonConfig.java
+++ b/src/main/java/github/ticketflow/config/RedissonConfig.java
@@ -1,0 +1,23 @@
+package github.ticketflow.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Bean
+    public RedissonClient redisson() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://my-cache-server:6379")
+                .setConnectionMinimumIdleSize(10)
+                .setConnectionPoolSize(10);
+
+        return Redisson.create(config);
+    }
+
+}

--- a/src/main/java/github/ticketflow/config/exception/seat/SeatErrorResponsive.java
+++ b/src/main/java/github/ticketflow/config/exception/seat/SeatErrorResponsive.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum SeatErrorResponsive implements ErrorResponsive {
-    NOT_FOUND_SEAT(HttpStatus.NOT_FOUND, "좌석을 찾을 수 없습니다.");
+    NOT_FOUND_SEAT(HttpStatus.NOT_FOUND, "좌석을 찾을 수 없습니다."),
+    FILL_SEAT(HttpStatus.BAD_REQUEST, "이미 선택된 자석입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/github/ticketflow/domian/seat/SeatController.java
+++ b/src/main/java/github/ticketflow/domian/seat/SeatController.java
@@ -32,6 +32,11 @@ public class SeatController {
         return ResponseEntity.ok(new SeatResponseDTO(seatService.createSeat(dto)));
     }
 
+    @PatchMapping("select/{seatId}")
+    public ResponseEntity<SeatResponseDTO> selectSeatById(@PathVariable Long seatId) {
+        return ResponseEntity.ok(new SeatResponseDTO(seatService.selectSeat(seatId)));
+    }
+
     @PatchMapping("/{seatId}")
     public ResponseEntity<SeatResponseDTO> updateSeat(@PathVariable Long seatId,
                                                       @Valid @RequestBody SeatUpdateRequestDTO dto) {

--- a/src/main/java/github/ticketflow/domian/seat/SeatEntity.java
+++ b/src/main/java/github/ticketflow/domian/seat/SeatEntity.java
@@ -48,6 +48,15 @@ public class SeatEntity {
         this.seatStatus = SeatStatus.EMPTY;
     }
 
+    public SeatEntity(Long id, SeatGradeEntity seatGradeEntity, String seatZone, int seatRow, int seatNumber) {
+        this.seatId = id;
+        this.seatGradeEntity = seatGradeEntity;
+        this.seatZone = seatZone;
+        this.seatRow = seatRow;
+        this.seatNumber = seatNumber;
+        this.seatStatus = SeatStatus.EMPTY;
+    }
+
     public SeatEntity updateSeatStatus(SeatStatus seatStatus) {
         this.seatStatus = seatStatus;
         return this;

--- a/src/main/java/github/ticketflow/domian/seat/SeatEntity.java
+++ b/src/main/java/github/ticketflow/domian/seat/SeatEntity.java
@@ -36,11 +36,21 @@ public class SeatEntity {
     @Column(name = "seat_number")
     private int seatNumber;
 
+    @Column(name = "seat_status")
+    @Enumerated(EnumType.STRING)
+    private SeatStatus seatStatus;
+
     public SeatEntity(SeatRequestDTO dto, SeatGradeEntity seatGradeEntity) {
         this.seatGradeEntity = seatGradeEntity;
         this.seatZone = dto.getSeatZone();
         this.seatRow = dto.getSeatRow();
         this.seatNumber = dto.getSeatNumber();
+        this.seatStatus = SeatStatus.EMPTY;
+    }
+
+    public SeatEntity updateSeatStatus(SeatStatus seatStatus) {
+        this.seatStatus = seatStatus;
+        return this;
     }
 
     public SeatEntity update(SeatUpdateRequestDTO dto, SeatGradeEntity seatGradeEntity) {

--- a/src/main/java/github/ticketflow/domian/seat/SeatService.java
+++ b/src/main/java/github/ticketflow/domian/seat/SeatService.java
@@ -74,4 +74,13 @@ public class SeatService {
         return seatGradeRepository.findById(seatGradeId).orElseThrow(() ->
                 new GlobalCommonException(SeatGradeErrorResponsive.NOT_FOUND_SEAT_GRADE));
     }
+
+    public SeatEntity selectSeat(Long seatId) {
+        SeatEntity seatEntity = getSeatById(seatId);
+        if(seatEntity.getSeatStatus() == SeatStatus.SELECT) {
+            throw new GlobalCommonException(SeatErrorResponsive.FILL_SEAT);
+        }
+        seatEntity.updateSeatStatus(SeatStatus.SELECT);
+        return seatRepository.save(seatEntity);
+    }
 }

--- a/src/main/java/github/ticketflow/domian/seat/SeatStatus.java
+++ b/src/main/java/github/ticketflow/domian/seat/SeatStatus.java
@@ -1,0 +1,8 @@
+package github.ticketflow.domian.seat;
+
+public enum SeatStatus {
+
+    EMPTY,
+    SELECT
+
+}

--- a/src/test/java/github/ticketflow/domian/seat/SeatServiceTest.java
+++ b/src/test/java/github/ticketflow/domian/seat/SeatServiceTest.java
@@ -156,7 +156,7 @@ class SeatServiceTest {
         BDDMockito.given(mockLock.tryLock(any(Long.class), any(Long.class), any(TimeUnit.class)))
             .willAnswer(invocation -> {
                 if (internalLock.tryLock()) {
-                    return true; // 한 번에 하나의 스레드만 true 반환
+                    return true;
                 }
                 return false;
             });


### PR DESCRIPTION
### 요약
예매하기 에서 첫 번째 순서인 좌석을 선택하기 에서 한 자리에 한 명만 선택을 하도록 동시성을 제어합니다.

### 상세 설명
- 좌석 선택 비지니스 로직을 작성을 했습니다.
- redisson을 설정을 해주었습니다.
- 비지니스 로직에 redisson을 이용한 Lock을 이용해서 동시성을 제어를 했습니다.

### 관련 이슈
이 PR은 [Feat] 회원 탈퇴 기능 및 테스트 #6 이슈를 해결하기 위해서 진행되었습니다.

### 테스트
- 탈퇴한 회원의 정보가 탈퇴 후 잘 반환이 되는지를 테스트를 했습니다.