### PR TITLE
[Modify] Redisson을 이용한 Lock AOP로 분리

### DIFF
--- a/src/main/java/github/ticketflow/config/aop/DistributedLock.java
+++ b/src/main/java/github/ticketflow/config/aop/DistributedLock.java
@@ -1,0 +1,16 @@
+package github.ticketflow.config.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    String key();
+
+}
+
+

--- a/src/main/java/github/ticketflow/config/aop/DistributedLockAspect.java
+++ b/src/main/java/github/ticketflow/config/aop/DistributedLockAspect.java
@@ -37,6 +37,4 @@ public class DistributedLockAspect {
             }
         }
     }
-    }
-
 }

--- a/src/main/java/github/ticketflow/config/aop/DistributedLockAspect.java
+++ b/src/main/java/github/ticketflow/config/aop/DistributedLockAspect.java
@@ -1,0 +1,42 @@
+package github.ticketflow.config.aop;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(distributedLock)")
+    public Object lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+        String lockKey = distributedLock.key();
+        RLock lock = redissonClient.getLock(lockKey);
+
+        boolean isLocked = false;
+
+        try {
+            isLocked = lock.tryLock(5, 20, TimeUnit.SECONDS);
+            if (isLocked) {
+                return joinPoint.proceed();
+            } else {
+                throw new IllegalStateException("Could not acquire lock for key: " + lockKey);
+            }
+        } finally {
+            if (isLocked) {
+                lock.unlock();
+            }
+        }
+    }
+    }
+
+}


### PR DESCRIPTION
### 요약
동시성 제어 로직과 비지니스 로직을 분리를 해서 가독성을 높이고 유지보수성과 재사용성을 높입니다.

### 상세 설명
- DistributedLock 어노테이션을 만듭니다.
- DistributedLockAspect AOP 클래스를 만듭니다.
- DistributedLock을 selectSeat메소드에 붙혀줍니다.

### 관련 이슈
이 PR은 #48 이슈를 해결하기 위해서 진행되었습니다.