### PR TITLE
[Feat] 경기 조회 성능 개선하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     // redisson
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.20.0'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
 }
 

--- a/src/main/java/github/ticketflow/config/RedissonConfig.java
+++ b/src/main/java/github/ticketflow/config/RedissonConfig.java
@@ -3,15 +3,25 @@ package github.ticketflow.config;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 public class RedissonConfig {
 
     @Bean
-    @Profile("!test")
+    @Profile("test")
     public RedissonClient redisson() {
         Config config = new Config();
         config.useSingleServer()
@@ -22,4 +32,20 @@ public class RedissonConfig {
         return Redisson.create(config);
     }
 
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory("my-cache-server", 6379);
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofDays(7))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(cacheConfig)
+                .build();
+    }
 }

--- a/src/main/java/github/ticketflow/config/RedissonConfig.java
+++ b/src/main/java/github/ticketflow/config/RedissonConfig.java
@@ -1,5 +1,7 @@
 package github.ticketflow.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
@@ -39,10 +41,15 @@ public class RedissonConfig {
 
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
         RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(Duration.ofDays(7))
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
 
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(cacheConfig)

--- a/src/main/java/github/ticketflow/domian/event/EventController.java
+++ b/src/main/java/github/ticketflow/domian/event/EventController.java
@@ -13,7 +13,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/event")
-public class EventController {
+public class  EventController {
 
     private final EventFacade eventFacade;
 

--- a/src/main/java/github/ticketflow/domian/event/EventService.java
+++ b/src/main/java/github/ticketflow/domian/event/EventService.java
@@ -28,7 +28,7 @@ public class EventService {
         );
     }
 
-    @Cacheable(value = "events", key = "#categoryId")
+    @Cacheable(value = "events", key = "#categoryEventEntities.content[0].categoryEntity.categoryId")
     public List<EventResponseDTO> getEventByCategoryId(Page<CategoryEventEntity> categoryEventEntities) {
         List<EventResponseDTO> eventEntities = new ArrayList<>();
 

--- a/src/main/java/github/ticketflow/domian/event/EventService.java
+++ b/src/main/java/github/ticketflow/domian/event/EventService.java
@@ -8,6 +8,8 @@ import github.ticketflow.domian.event.dto.EventResponseDTO;
 import github.ticketflow.domian.event.dto.EventUpdateRequestDTO;
 import github.ticketflow.domian.eventLocation.EventLocationEntity;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RedissonClient;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +28,7 @@ public class EventService {
         );
     }
 
+    @Cacheable(value = "events", key = "#categoryId")
     public List<EventResponseDTO> getEventByCategoryId(Page<CategoryEventEntity> categoryEventEntities) {
         List<EventResponseDTO> eventEntities = new ArrayList<>();
 


### PR DESCRIPTION
### 요약
경기 조회 기능의 성능을 개선하기 위해서 redis를 이용해서 구현을 캐시 기능을 사용했습니다.

### 상세 설명
- redis 캐시 설정을 했습니다.
- 경기 조회를 했을 시 redis에 저장 후 캐시를 할 수 있도록 구현을 했습니다.

### 관련 이슈
이 PR은 #53 이슈를 해결하기 위해서 진행되었습니다.
